### PR TITLE
Fix hardcoded dark-theme colors for light-theme support

### DIFF
--- a/lib/presentation/screens/history_screen.dart
+++ b/lib/presentation/screens/history_screen.dart
@@ -25,10 +25,14 @@ class HistoryScreen extends ConsumerWidget {
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (e, _) => Center(child: Text('Error: $e')),
                 data: (rides) => rides.isEmpty
-                    ? const Center(
+                    ? Center(
                         child: Text(
                           'No rides found',
-                          style: TextStyle(color: Colors.white38),
+                          style: TextStyle(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurface.withValues(alpha: 0.38),
+                          ),
                         ),
                       )
                     : _RideList(rides: rides),
@@ -63,8 +67,11 @@ class _RideList extends ConsumerWidget {
           background: Container(
             alignment: Alignment.centerRight,
             padding: const EdgeInsets.only(right: 24),
-            color: Colors.redAccent,
-            child: const Icon(Icons.delete, color: Colors.white),
+            color: Theme.of(context).colorScheme.error,
+            child: Icon(
+              Icons.delete,
+              color: Theme.of(context).colorScheme.onError,
+            ),
           ),
           confirmDismiss: (_) => _confirmDelete(context),
           onDismissed: (_) async {
@@ -135,7 +142,9 @@ class _RideCard extends StatelessWidget {
                   ),
                   Text(
                     _formatDuration(s.durationSeconds),
-                    style: const TextStyle(color: Colors.white54),
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                   ),
                 ],
               ),

--- a/lib/presentation/screens/pdc_screen.dart
+++ b/lib/presentation/screens/pdc_screen.dart
@@ -25,10 +25,14 @@ class PdcScreen extends ConsumerWidget {
                 loading: () => const Center(child: CircularProgressIndicator()),
                 error: (e, _) => Center(child: Text('Error: $e')),
                 data: (range) => range == null
-                    ? const Center(
+                    ? Center(
                         child: Text(
                           'No ride data yet',
-                          style: TextStyle(color: Colors.white38),
+                          style: TextStyle(
+                            color: Theme.of(
+                              context,
+                            ).colorScheme.onSurface.withValues(alpha: 0.38),
+                          ),
                         ),
                       )
                     : _PdcContent(range: range),
@@ -102,7 +106,10 @@ class _StatCards extends StatelessWidget {
                 children: [
                   Text(
                     '${d}s',
-                    style: const TextStyle(fontSize: 12, color: Colors.white54),
+                    style: TextStyle(
+                      fontSize: 12,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
                   ),
                   const SizedBox(height: 2),
                   Text(

--- a/lib/presentation/screens/ride_detail_screen.dart
+++ b/lib/presentation/screens/ride_detail_screen.dart
@@ -280,7 +280,10 @@ class _Stat extends StatelessWidget {
         ),
         Text(
           label,
-          style: const TextStyle(fontSize: 11, color: Colors.white54),
+          style: TextStyle(
+            fontSize: 11,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
       ],
     );

--- a/lib/presentation/screens/ride_screen.dart
+++ b/lib/presentation/screens/ride_screen.dart
@@ -391,12 +391,15 @@ class _ChartMode extends StatelessWidget {
         child: Column(
           children: [
             if (!isLandscape) _ModeSegmentedControl(ref: ref),
-            const Expanded(
+            Expanded(
               child: Center(
                 child: Text(
                   'Chart mode\n(coming soon)',
                   textAlign: TextAlign.center,
-                  style: TextStyle(fontSize: 18, color: Colors.white54),
+                  style: TextStyle(
+                    fontSize: 18,
+                    color: Theme.of(context).colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ),
             ),
@@ -462,11 +465,16 @@ class _RideControlsState extends State<_RideControls>
             onPressed: widget.onLap,
             style: ElevatedButton.styleFrom(
               shape: const CircleBorder(),
-              backgroundColor: Colors.white24,
+              backgroundColor: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.24),
             ),
-            child: const Text(
+            child: Text(
               'LAP',
-              style: TextStyle(fontSize: 16, color: Colors.white),
+              style: TextStyle(
+                fontSize: 16,
+                color: Theme.of(context).colorScheme.onSurface,
+              ),
             ),
           ),
         ),
@@ -489,10 +497,16 @@ class _RideControlsState extends State<_RideControls>
                     CircularProgressIndicator(
                       value: _stopProgress.value,
                       strokeWidth: 4,
-                      color: Colors.redAccent,
-                      backgroundColor: Colors.white24,
+                      color: Theme.of(context).colorScheme.error,
+                      backgroundColor: Theme.of(
+                        context,
+                      ).colorScheme.onSurface.withValues(alpha: 0.24),
                     ),
-                    const Icon(Icons.stop, color: Colors.white, size: 32),
+                    Icon(
+                      Icons.stop,
+                      color: Theme.of(context).colorScheme.onSurface,
+                      size: 32,
+                    ),
                   ],
                 );
               },
@@ -556,14 +570,18 @@ class _ModeButton extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
         decoration: BoxDecoration(
-          color: selected ? Colors.white24 : Colors.transparent,
+          color: selected
+              ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.24)
+              : Colors.transparent,
           borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: Colors.white38),
+          border: Border.all(color: Theme.of(context).colorScheme.outline),
         ),
         child: Text(
           label,
           style: TextStyle(
-            color: selected ? Colors.white : Colors.white54,
+            color: selected
+                ? Theme.of(context).colorScheme.onSurface
+                : Theme.of(context).colorScheme.onSurfaceVariant,
             fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
           ),
         ),
@@ -591,8 +609,8 @@ class _SensorStatusBar extends StatelessWidget {
       _ => '○ No sensor',
     };
     final color = connState.asData?.value == BleConnectionState.connected
-        ? Colors.greenAccent
-        : Colors.white54;
+        ? Colors.green
+        : Theme.of(context).colorScheme.onSurfaceVariant;
 
     return GestureDetector(
       onTap: () => showDeviceSheet(context),
@@ -616,15 +634,18 @@ class _SmallStat extends StatelessWidget {
       children: [
         Text(
           value,
-          style: const TextStyle(
+          style: TextStyle(
             fontSize: 28,
             fontWeight: FontWeight.w700,
-            color: Colors.white,
+            color: Theme.of(context).colorScheme.onSurface,
           ),
         ),
         Text(
           label,
-          style: const TextStyle(fontSize: 12, color: Colors.white60),
+          style: TextStyle(
+            fontSize: 12,
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
         ),
       ],
     );
@@ -642,16 +663,16 @@ class _LastEffortCard extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
       decoration: BoxDecoration(
-        color: Colors.white12,
+        color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.12),
         borderRadius: BorderRadius.circular(12),
       ),
       child: Column(
         children: [
           Text(
             'Effort ${effort.effortNumber}',
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 14,
-              color: Colors.white60,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
               fontWeight: FontWeight.w600,
             ),
           ),
@@ -659,11 +680,17 @@ class _LastEffortCard extends StatelessWidget {
           Text(
             '${s.avgPower.round()} W avg  •  '
             '${s.peakPower.round()} W peak',
-            style: const TextStyle(fontSize: 16, color: Colors.white),
+            style: TextStyle(
+              fontSize: 16,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
           ),
           Text(
             _formatDuration(s.durationSeconds),
-            style: const TextStyle(fontSize: 14, color: Colors.white70),
+            style: TextStyle(
+              fontSize: 14,
+              color: Theme.of(context).colorScheme.onSurface,
+            ),
           ),
         ],
       ),

--- a/lib/presentation/widgets/device_sheet.dart
+++ b/lib/presentation/widgets/device_sheet.dart
@@ -110,7 +110,9 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
             height: 4,
             margin: const EdgeInsets.only(bottom: 12),
             decoration: BoxDecoration(
-              color: Colors.white38,
+              color: Theme.of(
+                context,
+              ).colorScheme.onSurface.withValues(alpha: 0.38),
               borderRadius: BorderRadius.circular(2),
             ),
           ),
@@ -167,11 +169,13 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
   ) {
     if (devices.isEmpty) {
       return [
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 8),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
           child: Text(
             'No remembered devices',
-            style: TextStyle(color: Colors.white54),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
         ),
       ];
@@ -189,17 +193,23 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
           isThisConnected ? _connectionLabel(stateValue) : 'Saved',
           style: TextStyle(
             color: stateValue == BleConnectionState.connected
-                ? Colors.greenAccent
-                : Colors.white54,
+                ? Colors.green
+                : Theme.of(context).colorScheme.onSurfaceVariant,
           ),
         ),
         trailing: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
             if (!device.autoConnect)
-              const Tooltip(
+              Tooltip(
                 message: 'Auto-connect off',
-                child: Icon(Icons.link_off, size: 16, color: Colors.white38),
+                child: Icon(
+                  Icons.link_off,
+                  size: 16,
+                  color: Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.38),
+                ),
               ),
             PopupMenuButton<_DeviceAction>(
               icon: const Icon(Icons.more_vert, size: 20),
@@ -237,22 +247,26 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
 
     if (filtered.isEmpty && _scanResults.isEmpty) {
       return [
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 16),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16),
           child: Text(
             'Scanning\u2026',
-            style: TextStyle(color: Colors.white54),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
         ),
       ];
     }
     if (filtered.isEmpty) {
       return [
-        const Padding(
-          padding: EdgeInsets.symmetric(vertical: 16),
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 16),
           child: Text(
             'No new devices found',
-            style: TextStyle(color: Colors.white54),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
         ),
       ];
@@ -391,11 +405,11 @@ class _ServiceIcons extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: [
         if (services.contains(SensorType.power))
-          const Icon(Icons.bolt, size: 18, color: Colors.amberAccent),
+          const Icon(Icons.bolt, size: 18, color: Colors.amber),
         if (services.contains(SensorType.heartRate))
-          const Icon(Icons.favorite, size: 18, color: Colors.redAccent),
+          const Icon(Icons.favorite, size: 18, color: Colors.red),
         if (services.contains(SensorType.cadence))
-          const Icon(Icons.speed, size: 18, color: Colors.lightBlueAccent),
+          const Icon(Icons.speed, size: 18, color: Colors.blue),
       ],
     );
   }
@@ -412,13 +426,13 @@ class _SignalIcon extends StatelessWidget {
     final Color color;
     if (rssi > -60) {
       icon = Icons.signal_cellular_alt;
-      color = Colors.greenAccent;
+      color = Colors.green;
     } else if (rssi > -80) {
       icon = Icons.signal_cellular_alt_2_bar;
-      color = Colors.amberAccent;
+      color = Colors.amber;
     } else {
       icon = Icons.signal_cellular_alt_1_bar;
-      color = Colors.redAccent;
+      color = Colors.red;
     }
     return Icon(icon, size: 20, color: color);
   }

--- a/lib/presentation/widgets/effort_card.dart
+++ b/lib/presentation/widgets/effort_card.dart
@@ -30,14 +30,15 @@ class EffortCard extends StatelessWidget {
           duration: const Duration(milliseconds: 250),
           crossFadeState:
               isExpanded ? CrossFadeState.showSecond : CrossFadeState.showFirst,
-          firstChild: _collapsed(s),
+          firstChild: _collapsed(context, s),
           secondChild: _expanded(s),
         ),
       ),
     );
   }
 
-  Widget _collapsed(EffortSummary s) {
+  Widget _collapsed(BuildContext context, EffortSummary s) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       child: Row(
@@ -58,7 +59,10 @@ class EffortCard extends StatelessWidget {
                   '${_dur(s.durationSeconds)}  \u2022  '
                   '${s.avgPower.round()} W avg  \u2022  '
                   '${s.peakPower.round()} W peak',
-                  style: const TextStyle(fontSize: 12, color: Colors.white70),
+                  style: TextStyle(
+                    fontSize: 12,
+                    color: colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ],
             ),
@@ -137,7 +141,10 @@ class _StatRow extends StatelessWidget {
         children: [
           Text(
             label,
-            style: const TextStyle(color: Colors.white54, fontSize: 13),
+            style: TextStyle(
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              fontSize: 13,
+            ),
           ),
           Text(value, style: const TextStyle(fontSize: 13)),
         ],

--- a/lib/presentation/widgets/effort_timeline.dart
+++ b/lib/presentation/widgets/effort_timeline.dart
@@ -36,6 +36,9 @@ class EffortTimeline extends StatelessWidget {
         painter: _TimelinePainter(
           efforts: efforts,
           totalDuration: totalDurationSeconds,
+          bgColor: Theme.of(
+            context,
+          ).colorScheme.onSurface.withValues(alpha: 0.12),
         ),
         child: const SizedBox(height: 40, width: double.infinity),
       ),
@@ -44,15 +47,20 @@ class EffortTimeline extends StatelessWidget {
 }
 
 class _TimelinePainter extends CustomPainter {
-  _TimelinePainter({required this.efforts, required this.totalDuration});
+  _TimelinePainter({
+    required this.efforts,
+    required this.totalDuration,
+    required this.bgColor,
+  });
 
   final List<Effort> efforts;
   final int totalDuration;
+  final Color bgColor;
 
   @override
   void paint(Canvas canvas, Size size) {
     // Background bar.
-    final bgPaint = Paint()..color = Colors.white12;
+    final bgPaint = Paint()..color = bgColor;
     canvas.drawRRect(
       RRect.fromRectAndRadius(Offset.zero & size, const Radius.circular(4)),
       bgPaint,
@@ -105,5 +113,6 @@ class _TimelinePainter extends CustomPainter {
   @override
   bool shouldRepaint(_TimelinePainter oldDelegate) =>
       efforts != oldDelegate.efforts ||
-      totalDuration != oldDelegate.totalDuration;
+      totalDuration != oldDelegate.totalDuration ||
+      bgColor != oldDelegate.bgColor;
 }

--- a/lib/presentation/widgets/map_curve_chart.dart
+++ b/lib/presentation/widgets/map_curve_chart.dart
@@ -23,6 +23,7 @@ class MapCurveChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     final spots = <FlSpot>[];
     for (var i = 0; i < curve.values.length; i++) {
       final v = curve.values[i];
@@ -31,8 +32,13 @@ class MapCurveChart extends StatelessWidget {
     if (spots.isEmpty) {
       return SizedBox(
         height: compact ? 48 : 200,
-        child: const Center(
-          child: Text('No data', style: TextStyle(color: Colors.white38)),
+        child: Center(
+          child: Text(
+            'No data',
+            style: TextStyle(
+              color: colorScheme.onSurface.withValues(alpha: 0.38),
+            ),
+          ),
         ),
       );
     }
@@ -43,12 +49,12 @@ class MapCurveChart extends StatelessWidget {
       spots: spots,
       isCurved: true,
       curveSmoothness: 0.2,
-      color: Colors.cyanAccent,
+      color: colorScheme.primary,
       barWidth: compact ? 1.5 : 2.5,
       dotData: const FlDotData(show: false),
       belowBarData: BarAreaData(
         show: !compact,
-        color: Colors.cyanAccent.withValues(alpha: 0.1),
+        color: colorScheme.primary.withValues(alpha: 0.1),
       ),
     );
 
@@ -85,7 +91,7 @@ class MapCurveChart extends StatelessWidget {
         BetweenBarsData(
           fromIndex: 1,
           toIndex: 2,
-          color: Colors.white.withValues(alpha: 0.08),
+          color: colorScheme.onSurface.withValues(alpha: 0.08),
         ),
       );
     }
@@ -111,9 +117,9 @@ class MapCurveChart extends StatelessWidget {
                       reservedSize: 40,
                       getTitlesWidget: (value, meta) => Text(
                         value.toInt().toString(),
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 10,
-                          color: Colors.white38,
+                          color: colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ),
@@ -125,9 +131,9 @@ class MapCurveChart extends StatelessWidget {
                       interval: 15,
                       getTitlesWidget: (value, meta) => Text(
                         '${value.toInt()}s',
-                        style: const TextStyle(
+                        style: TextStyle(
                           fontSize: 10,
-                          color: Colors.white38,
+                          color: colorScheme.onSurfaceVariant,
                         ),
                       ),
                     ),
@@ -144,8 +150,8 @@ class MapCurveChart extends StatelessWidget {
                       final label = _tooltipLabel(s);
                       return LineTooltipItem(
                         label,
-                        const TextStyle(
-                          color: Colors.white,
+                        TextStyle(
+                          color: colorScheme.onInverseSurface,
                           fontSize: 12,
                           fontWeight: FontWeight.w600,
                         ),


### PR DESCRIPTION
## Summary
Replace ~50 hardcoded dark-theme colors across 8 presentation files with Material 3 colorScheme equivalents. Chart lines now use `colorScheme.primary`, text colors use `onSurface`/`onSurfaceVariant`/`onError` based on semantic purpose, and accent colors (amber/green/red/blue) work in both light and dark themes.

The focus mode dark HUD background gradient and white text overlay are intentionally left unchanged—they form a self-contained dark context regardless of theme setting.

## Testing
All 278 tests pass. Static analysis clean (flutter analyze). Verified color mapping across:
- Map curve chart (axes, tooltip, historical band)
- Effort cards and timeline
- Device sheet (remembered/nearby devices, connection status, signal icons)
- Ride screen (LAP/STOP buttons, mode selector, sensor status bar, stats)
- History/PDC/detail screens

🤖 Generated with Claude Code