### PR TITLE
Phase 4b Item 23: Desktop interaction polish

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -59,7 +59,7 @@ Tracks completion status per item in the implementation order (spec-supplement �
 | 20 | Platform scaffolding (macOS/Windows/Linux/Android dirs, entitlements, min window size) | ✅ Done | macOS (BLE entitlements, min window 400×600), Windows, Linux platforms added. wakelock_plus Linux guard. |
 | 21 | Responsive layout (breakpoints, AdaptiveShell, LayoutBuilder in RideScreen) | ✅ Done | `breakpoints.dart` (compact/medium/expanded). AppShell: NavigationBar (compact) ↔ NavigationRail (medium/expanded). RideScreen: side-by-side Focus+Chart at ≥900dp. Device sheet: bottom sheet (<600dp) ↔ dialog (≥600dp). |
 | 22 | Keyboard shortcuts (intents, shortcut map, Focus widget wiring) | ✅ Done | 6 Intent classes, 2 shortcut maps (active/idle). `_IdleView`/`_ActiveView` converted to `ConsumerStatefulWidget`, wrapped with `Shortcuts`+`Actions`+`Focus`. Escape→stop confirmation dialog. Focus restored after dialogs. |
-| 23 | Desktop interaction polish (mouse cursors, tooltips, hover states, adaptive device dialog) | ⬜ Pending |
+| 23 | Desktop interaction polish (mouse cursors, tooltips, hover states, adaptive device dialog) | ✅ Done | Tooltips with shortcut hints on ride controls (LAP, STOP, Start, mode buttons, sensor bar). MouseRegion click cursors on STOP, sensor bar, device list items, effort timeline. InkWell with hover ripple on mode buttons. mouseCursor on effort cards. |
 
 ## Other
 

--- a/lib/presentation/screens/ride_screen.dart
+++ b/lib/presentation/screens/ride_screen.dart
@@ -87,20 +87,23 @@ class _IdleViewState extends ConsumerState<_IdleView> {
                     ],
                     _SensorStatusBar(ref: ref),
                     const SizedBox(height: 32),
-                    SizedBox(
-                      width: double.infinity,
-                      height: 56,
-                      child: ElevatedButton(
-                        onPressed: isConnected
-                            ? () => ref
-                                .read(rideSessionProvider.notifier)
-                                .startRide()
-                            : () => showDeviceSheet(context),
-                        child: Text(
-                          isConnected
-                              ? 'Start Ride'
-                              : 'Connect a sensor to start',
-                          style: const TextStyle(fontSize: 18),
+                    Tooltip(
+                      message: 'Start ride (Enter)',
+                      child: SizedBox(
+                        width: double.infinity,
+                        height: 56,
+                        child: ElevatedButton(
+                          onPressed: isConnected
+                              ? () => ref
+                                  .read(rideSessionProvider.notifier)
+                                  .startRide()
+                              : () => showDeviceSheet(context),
+                          child: Text(
+                            isConnected
+                                ? 'Start Ride'
+                                : 'Connect a sensor to start',
+                            style: const TextStyle(fontSize: 18),
+                          ),
                         ),
                       ),
                     ),
@@ -458,58 +461,67 @@ class _RideControlsState extends State<_RideControls>
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       children: [
-        SizedBox(
-          width: 72,
-          height: 72,
-          child: ElevatedButton(
-            onPressed: widget.onLap,
-            style: ElevatedButton.styleFrom(
-              shape: const CircleBorder(),
-              backgroundColor: Theme.of(
-                context,
-              ).colorScheme.onSurface.withValues(alpha: 0.24),
-            ),
-            child: Text(
-              'LAP',
-              style: TextStyle(
-                fontSize: 16,
-                color: Theme.of(context).colorScheme.onSurface,
+        Tooltip(
+          message: 'Manual lap (Space)',
+          child: SizedBox(
+            width: 72,
+            height: 72,
+            child: ElevatedButton(
+              onPressed: widget.onLap,
+              style: ElevatedButton.styleFrom(
+                shape: const CircleBorder(),
+                backgroundColor: Theme.of(
+                  context,
+                ).colorScheme.onSurface.withValues(alpha: 0.24),
+              ),
+              child: Text(
+                'LAP',
+                style: TextStyle(
+                  fontSize: 16,
+                  color: Theme.of(context).colorScheme.onSurface,
+                ),
               ),
             ),
           ),
         ),
-        GestureDetector(
-          onLongPressStart: (_) => _stopProgress.forward(from: 0),
-          onLongPressEnd: (_) {
-            if (_stopProgress.status != AnimationStatus.completed) {
-              _stopProgress.reset();
-            }
-          },
-          child: SizedBox(
-            width: 72,
-            height: 72,
-            child: AnimatedBuilder(
-              animation: _stopProgress,
-              builder: (context, child) {
-                return Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    CircularProgressIndicator(
-                      value: _stopProgress.value,
-                      strokeWidth: 4,
-                      color: Theme.of(context).colorScheme.error,
-                      backgroundColor: Theme.of(
-                        context,
-                      ).colorScheme.onSurface.withValues(alpha: 0.24),
-                    ),
-                    Icon(
-                      Icons.stop,
-                      color: Theme.of(context).colorScheme.onSurface,
-                      size: 32,
-                    ),
-                  ],
-                );
+        Tooltip(
+          message: 'Stop ride (hold 1.5s or Esc)',
+          child: MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onLongPressStart: (_) => _stopProgress.forward(from: 0),
+              onLongPressEnd: (_) {
+                if (_stopProgress.status != AnimationStatus.completed) {
+                  _stopProgress.reset();
+                }
               },
+              child: SizedBox(
+                width: 72,
+                height: 72,
+                child: AnimatedBuilder(
+                  animation: _stopProgress,
+                  builder: (context, child) {
+                    return Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        CircularProgressIndicator(
+                          value: _stopProgress.value,
+                          strokeWidth: 4,
+                          color: Theme.of(context).colorScheme.error,
+                          backgroundColor: Theme.of(
+                            context,
+                          ).colorScheme.onSurface.withValues(alpha: 0.24),
+                        ),
+                        Icon(
+                          Icons.stop,
+                          color: Theme.of(context).colorScheme.onSurface,
+                          size: 32,
+                        ),
+                      ],
+                    );
+                  },
+                ),
+              ),
             ),
           ),
         ),
@@ -539,12 +551,14 @@ class _ModeSegmentedControl extends StatelessWidget {
             label: 'Focus',
             selected: mode == RideMode.focus,
             onTap: () => ref.read(rideModeProvider.notifier).setFocus(),
+            tooltip: 'Focus mode (\u2190)',
           ),
           const SizedBox(width: 8),
           _ModeButton(
             label: 'Chart',
             selected: mode == RideMode.chart,
             onTap: () => ref.read(rideModeProvider.notifier).setChart(),
+            tooltip: 'Chart mode (\u2192)',
           ),
         ],
       ),
@@ -557,32 +571,40 @@ class _ModeButton extends StatelessWidget {
     required this.label,
     required this.selected,
     required this.onTap,
+    required this.tooltip,
   });
 
   final String label;
   final bool selected;
   final VoidCallback onTap;
+  final String tooltip;
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
-        decoration: BoxDecoration(
-          color: selected
-              ? Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.24)
-              : Colors.transparent,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: Theme.of(context).colorScheme.outline),
-        ),
-        child: Text(
-          label,
-          style: TextStyle(
+    return Tooltip(
+      message: tooltip,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(16),
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+          decoration: BoxDecoration(
             color: selected
-                ? Theme.of(context).colorScheme.onSurface
-                : Theme.of(context).colorScheme.onSurfaceVariant,
-            fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+                ? Theme.of(
+                    context,
+                  ).colorScheme.onSurface.withValues(alpha: 0.24)
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: Theme.of(context).colorScheme.outline),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              color: selected
+                  ? Theme.of(context).colorScheme.onSurface
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
+              fontWeight: selected ? FontWeight.w600 : FontWeight.normal,
+            ),
           ),
         ),
       ),
@@ -612,11 +634,17 @@ class _SensorStatusBar extends StatelessWidget {
         ? Colors.green
         : Theme.of(context).colorScheme.onSurfaceVariant;
 
-    return GestureDetector(
-      onTap: () => showDeviceSheet(context),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-        child: Text(label, style: TextStyle(fontSize: 13, color: color)),
+    return Tooltip(
+      message: 'Manage devices (D)',
+      child: MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: GestureDetector(
+          onTap: () => showDeviceSheet(context),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Text(label, style: TextStyle(fontSize: 13, color: color)),
+          ),
+        ),
       ),
     );
   }

--- a/lib/presentation/widgets/device_sheet.dart
+++ b/lib/presentation/widgets/device_sheet.dart
@@ -186,56 +186,59 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
           ? (connState.asData?.value ?? BleConnectionState.disconnected)
           : BleConnectionState.disconnected;
 
-      return ListTile(
-        leading: _ServiceIcons(services: device.supportedServices),
-        title: Text(device.displayName),
-        subtitle: Text(
-          isThisConnected ? _connectionLabel(stateValue) : 'Saved',
-          style: TextStyle(
-            color: stateValue == BleConnectionState.connected
-                ? Colors.green
-                : Theme.of(context).colorScheme.onSurfaceVariant,
+      return MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: ListTile(
+          leading: _ServiceIcons(services: device.supportedServices),
+          title: Text(device.displayName),
+          subtitle: Text(
+            isThisConnected ? _connectionLabel(stateValue) : 'Saved',
+            style: TextStyle(
+              color: stateValue == BleConnectionState.connected
+                  ? Colors.green
+                  : Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
           ),
-        ),
-        trailing: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            if (!device.autoConnect)
-              Tooltip(
-                message: 'Auto-connect off',
-                child: Icon(
-                  Icons.link_off,
-                  size: 16,
-                  color: Theme.of(
-                    context,
-                  ).colorScheme.onSurface.withValues(alpha: 0.38),
-                ),
-              ),
-            PopupMenuButton<_DeviceAction>(
-              icon: const Icon(Icons.more_vert, size: 20),
-              onSelected: (action) => _onDeviceAction(action, device),
-              itemBuilder: (_) => [
-                const PopupMenuItem(
-                  value: _DeviceAction.rename,
-                  child: Text('Rename'),
-                ),
-                PopupMenuItem(
-                  value: _DeviceAction.toggleAutoConnect,
-                  child: Text(
-                    device.autoConnect
-                        ? 'Disable auto-connect'
-                        : 'Enable auto-connect',
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (!device.autoConnect)
+                Tooltip(
+                  message: 'Auto-connect off',
+                  child: Icon(
+                    Icons.link_off,
+                    size: 16,
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.onSurface.withValues(alpha: 0.38),
                   ),
                 ),
-                const PopupMenuItem(
-                  value: _DeviceAction.forget,
-                  child: Text('Forget'),
-                ),
-              ],
-            ),
-          ],
+              PopupMenuButton<_DeviceAction>(
+                icon: const Icon(Icons.more_vert, size: 20),
+                onSelected: (action) => _onDeviceAction(action, device),
+                itemBuilder: (_) => [
+                  const PopupMenuItem(
+                    value: _DeviceAction.rename,
+                    child: Text('Rename'),
+                  ),
+                  PopupMenuItem(
+                    value: _DeviceAction.toggleAutoConnect,
+                    child: Text(
+                      device.autoConnect
+                          ? 'Disable auto-connect'
+                          : 'Enable auto-connect',
+                    ),
+                  ),
+                  const PopupMenuItem(
+                    value: _DeviceAction.forget,
+                    child: Text('Forget'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          onTap: () => _toggleConnection(device.deviceId, isThisConnected),
         ),
-        onTap: () => _toggleConnection(device.deviceId, isThisConnected),
       );
     }).toList();
   }
@@ -273,11 +276,14 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
     }
 
     return filtered.map((device) {
-      return ListTile(
-        leading: _ServiceIcons(services: device.advertisedServices),
-        title: Text(device.name.isNotEmpty ? device.name : 'Unknown'),
-        trailing: _SignalIcon(rssi: device.rssi),
-        onTap: () => _connectAndRemember(device),
+      return MouseRegion(
+        cursor: SystemMouseCursors.click,
+        child: ListTile(
+          leading: _ServiceIcons(services: device.advertisedServices),
+          title: Text(device.name.isNotEmpty ? device.name : 'Unknown'),
+          trailing: _SignalIcon(rssi: device.rssi),
+          onTap: () => _connectAndRemember(device),
+        ),
       );
     }).toList();
   }

--- a/lib/presentation/widgets/effort_card.dart
+++ b/lib/presentation/widgets/effort_card.dart
@@ -26,6 +26,7 @@ class EffortCard extends StatelessWidget {
       clipBehavior: Clip.antiAlias,
       child: InkWell(
         onTap: onToggle,
+        mouseCursor: SystemMouseCursors.click,
         child: AnimatedCrossFade(
           duration: const Duration(milliseconds: 250),
           crossFadeState:

--- a/lib/presentation/widgets/effort_timeline.dart
+++ b/lib/presentation/widgets/effort_timeline.dart
@@ -18,29 +18,33 @@ class EffortTimeline extends StatelessWidget {
   Widget build(BuildContext context) {
     if (totalDurationSeconds <= 0) return const SizedBox.shrink();
 
-    return GestureDetector(
-      onTapUp: onEffortTapped == null
-          ? null
-          : (details) {
-              final frac = details.localPosition.dx / context.size!.width;
-              final offset = (frac * totalDurationSeconds).round();
-              for (final e in efforts) {
-                if (offset >= e.startOffset &&
-                    offset <= e.startOffset + e.summary.durationSeconds) {
-                  onEffortTapped!(e.effortNumber);
-                  return;
+    return MouseRegion(
+      cursor:
+          onEffortTapped != null ? SystemMouseCursors.click : MouseCursor.defer,
+      child: GestureDetector(
+        onTapUp: onEffortTapped == null
+            ? null
+            : (details) {
+                final frac = details.localPosition.dx / context.size!.width;
+                final offset = (frac * totalDurationSeconds).round();
+                for (final e in efforts) {
+                  if (offset >= e.startOffset &&
+                      offset <= e.startOffset + e.summary.durationSeconds) {
+                    onEffortTapped!(e.effortNumber);
+                    return;
+                  }
                 }
-              }
-            },
-      child: CustomPaint(
-        painter: _TimelinePainter(
-          efforts: efforts,
-          totalDuration: totalDurationSeconds,
-          bgColor: Theme.of(
-            context,
-          ).colorScheme.onSurface.withValues(alpha: 0.12),
+              },
+        child: CustomPaint(
+          painter: _TimelinePainter(
+            efforts: efforts,
+            totalDuration: totalDurationSeconds,
+            bgColor: Theme.of(
+              context,
+            ).colorScheme.onSurface.withValues(alpha: 0.12),
+          ),
+          child: const SizedBox(height: 40, width: double.infinity),
         ),
-        child: const SizedBox(height: 40, width: double.infinity),
       ),
     );
   }


### PR DESCRIPTION
## Summary
Implement IG24 (desktop interaction polish): add tooltips with keyboard shortcut hints to all interactive elements, mouse cursor affordances via MouseRegion, and hover states. Replace custom mode button with InkWell for automatic ripple effect.

## Changes
- **Tooltips**: LAP (Space), STOP (hold 1.5s or Esc), Start (Enter), Focus mode (←), Chart mode (→), Manage devices (D)
- **Mouse cursors**: click pointer on STOP button, sensor status bar, device list items, effort timeline
- **Hover states**: InkWell on mode buttons for ripple feedback, mouseCursor on effort cards
- **Progress**: Updated Phase 4b Item 23 from Pending to Done in docs/progress.md

## Test Results
All 278 tests pass. `dart analyze` clean (1 pre-existing info-level warning unrelated to these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)