### PR TITLE
Add animated layout transitions on window resize

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -41,6 +41,8 @@ Tracks completion status per item in the implementation order (spec-supplement �
 
 **Phase 4 total (Items 15-20): 278 tests passing — Phase 4 COMPLETE**
 
+**Phase 5 total: 280 tests passing**
+
 ## Phase 4: Presentation
 
 | # | Item | Status |
@@ -71,7 +73,7 @@ Tracks completion status per item in the implementation order (spec-supplement �
 
 | # | Item | Status |
 |---|---|---|
-| 24 | Orientation handling + desktop window resize transitions | ⬜ Pending |
+| 24 | Orientation handling + desktop window resize transitions | ✅ Done | AnimatedSwitcher (300ms, easeInOut) in AppShell (nav rail ↔ bottom nav) and RideScreen _ActiveView (expanded/landscape/focus/chart). |
 | 25 | Animations and transitions | ⬜ Pending |
 | 26 | Re-detection preview | ⬜ Pending |
 | 27 | Bulk import UI | ⬜ Pending |

--- a/lib/presentation/screens/app_shell.dart
+++ b/lib/presentation/screens/app_shell.dart
@@ -83,8 +83,10 @@ class _AppShellState extends ConsumerState<AppShell> {
       builder: (context, constraints) {
         final layout = layoutSizeOf(constraints.maxWidth);
 
+        final Widget child;
         if (layout == LayoutSize.compact) {
-          return Scaffold(
+          child = Scaffold(
+            key: const ValueKey('compact'),
             body: IndexedStack(index: _selectedIndex, children: _screens),
             bottomNavigationBar: NavigationBar(
               selectedIndex: _selectedIndex,
@@ -92,25 +94,36 @@ class _AppShellState extends ConsumerState<AppShell> {
               destinations: _destinations,
             ),
           );
+        } else {
+          // Medium or Expanded: NavigationRail on the left.
+          child = Scaffold(
+            key: const ValueKey('rail'),
+            body: Row(
+              children: [
+                NavigationRail(
+                  selectedIndex: _selectedIndex,
+                  onDestinationSelected: (i) =>
+                      setState(() => _selectedIndex = i),
+                  labelType: NavigationRailLabelType.all,
+                  destinations: _railDestinations,
+                ),
+                const VerticalDivider(thickness: 1, width: 1),
+                Expanded(
+                  child: IndexedStack(
+                    index: _selectedIndex,
+                    children: _screens,
+                  ),
+                ),
+              ],
+            ),
+          );
         }
 
-        // Medium or Expanded: NavigationRail on the left.
-        return Scaffold(
-          body: Row(
-            children: [
-              NavigationRail(
-                selectedIndex: _selectedIndex,
-                onDestinationSelected: (i) =>
-                    setState(() => _selectedIndex = i),
-                labelType: NavigationRailLabelType.all,
-                destinations: _railDestinations,
-              ),
-              const VerticalDivider(thickness: 1, width: 1),
-              Expanded(
-                child: IndexedStack(index: _selectedIndex, children: _screens),
-              ),
-            ],
-          ),
+        return AnimatedSwitcher(
+          duration: const Duration(milliseconds: 300),
+          switchInCurve: Curves.easeInOut,
+          switchOutCurve: Curves.easeInOut,
+          child: child,
         );
       },
     );

--- a/lib/presentation/screens/ride_screen.dart
+++ b/lib/presentation/screens/ride_screen.dart
@@ -181,8 +181,10 @@ class _ActiveViewState extends ConsumerState<_ActiveView> {
               builder: (context, constraints) {
                 final layout = layoutSizeOf(constraints.maxWidth);
 
+                final Widget child;
                 if (layout == LayoutSize.expanded) {
-                  return Row(
+                  child = Row(
+                    key: const ValueKey('expanded'),
                     children: [
                       Expanded(
                         flex: 2,
@@ -198,24 +200,38 @@ class _ActiveViewState extends ConsumerState<_ActiveView> {
                       ),
                     ],
                   );
+                } else {
+                  final orientation = MediaQuery.orientationOf(context);
+                  if (orientation == Orientation.landscape) {
+                    child = _ChartMode(
+                      key: const ValueKey('landscape'),
+                      state: widget.state,
+                      ref: ref,
+                      isLandscape: true,
+                    );
+                  } else {
+                    final mode = ref.watch(rideModeProvider);
+                    child = mode == RideMode.focus
+                        ? _FocusMode(
+                            key: const ValueKey('focus'),
+                            state: widget.state,
+                            ref: ref,
+                          )
+                        : _ChartMode(
+                            key: const ValueKey('chart'),
+                            state: widget.state,
+                            ref: ref,
+                            isLandscape: false,
+                          );
+                  }
                 }
 
-                final orientation = MediaQuery.orientationOf(context);
-                if (orientation == Orientation.landscape) {
-                  return _ChartMode(
-                    state: widget.state,
-                    ref: ref,
-                    isLandscape: true,
-                  );
-                }
-                final mode = ref.watch(rideModeProvider);
-                return mode == RideMode.focus
-                    ? _FocusMode(state: widget.state, ref: ref)
-                    : _ChartMode(
-                        state: widget.state,
-                        ref: ref,
-                        isLandscape: false,
-                      );
+                return AnimatedSwitcher(
+                  duration: const Duration(milliseconds: 300),
+                  switchInCurve: Curves.easeInOut,
+                  switchOutCurve: Curves.easeInOut,
+                  child: child,
+                );
               },
             ),
           ),
@@ -256,7 +272,7 @@ class _ActiveViewState extends ConsumerState<_ActiveView> {
 // ---------------------------------------------------------------------------
 
 class _FocusMode extends StatelessWidget {
-  const _FocusMode({required this.state, required this.ref});
+  const _FocusMode({required this.state, required this.ref, super.key});
 
   final RideStateActive state;
   final WidgetRef ref;
@@ -381,6 +397,7 @@ class _ChartMode extends StatelessWidget {
     required this.state,
     required this.ref,
     required this.isLandscape,
+    super.key,
   });
 
   final RideStateActive state;


### PR DESCRIPTION
## Summary
Phase 5 Item 24: smooth 300ms AnimatedSwitcher cross-fades when layout breakpoints change.

**AppShell**: nav rail ↔ bottom nav transition at 600dp breakpoint (compact ↔ medium/expanded).

**RideScreen _ActiveView**: four keyed variants (expanded, landscape, focus, chart) animate smoothly when breakpoint changes or orientation flips.

Added `super.key` support to _FocusMode and _ChartMode constructors.

All 280 tests pass.