### PR TITLE
Add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wattalizer
 
+[![Build & Test](https://github.com/svenaron/wattalizer/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/svenaron/wattalizer/actions/workflows/ci.yml)
+
 A cross-platform mobile app for track cyclists and sprint athletes to analyze power output during sprint interval training.
 
 ## Features


### PR DESCRIPTION
Add a GitHub Actions status badge showing the CI workflow status on main branch.

The badge displays pass/fail status of the build and test suite, and links to the full workflow history.