### PR TITLE
Fix CI badge label in README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build & Test
 
 on:
   push:


### PR DESCRIPTION
The badge in README.md displays "CI" as the label, but should show "Build & Test" to match the workflow intent. GitHub Actions badges use the workflow's \`name:\` field as the label text.

Updated the workflow \`name:\` from "CI" to "Build & Test" so the badge renders correctly.