### PR TITLE
Phase 5 Item 27: Bulk import UI with progress and results

### DIFF
--- a/docs/progress.md
+++ b/docs/progress.md
@@ -41,7 +41,7 @@ Tracks completion status per item in the implementation order (spec-supplement �
 
 **Phase 4 total (Items 15-20): 278 tests passing — Phase 4 COMPLETE**
 
-**Phase 5 total: 279 tests passing (energy fields removed)**
+**Phase 5 total: 281 tests passing — Phase 5 COMPLETE**
 
 ## Phase 4: Presentation
 
@@ -76,4 +76,4 @@ Tracks completion status per item in the implementation order (spec-supplement �
 | 24 | Orientation handling + desktop window resize transitions | ✅ Done | AnimatedSwitcher (300ms, easeInOut) in AppShell (nav rail ↔ bottom nav) and RideScreen _ActiveView (expanded/landscape/focus/chart). |
 | 25 | Animations and transitions | ✅ Done | Focus mode: `AnimatedContainer` bg color + 700ms pulse overlay at >95% max power. Chart mode: full `fl_chart` impl (gradient live curve, faded previous efforts, historical band, record-breaking glow dots, key duration stats, power/HR/cadence header, landscape side panel). Sparkline widget (`CustomPainter`) + `ridePdcProvider` wired into history cards. |
 | 26 | Re-detection preview | ✅ Done | `RedetectPreviewSheet` bottom sheet/dialog. Config fields + preset selector + dual timeline comparison + Apply/Make Default. `updateRide` now also persists `effortCount` + `autoLapConfigId`. |
-| 27 | Bulk import UI | ⬜ Pending |
+| 27 | Bulk import UI | ✅ Done | Fixed persistence bug (importTcx now saves ride+readings+efforts+curves atomically). Added `onProgress` callback to `importZip`. Settings screen shows per-file progress ("Importing... 3/12") and detailed results dialog with per-file ✅/❌ rows and error type labels. |

--- a/lib/domain/services/export_service.dart
+++ b/lib/domain/services/export_service.dart
@@ -141,19 +141,35 @@ class ExportService {
       efforts,
     );
 
-    return Ride(
+    final ride = Ride(
       id: rideId,
       startTime: result.startTime,
       source: RideSource.importedTcx,
       efforts: efforts,
       summary: summary,
     );
+
+    // Persist atomically
+    await _repository.transaction(() async {
+      await _repository.saveRide(ride);
+      await _repository.insertReadings(rideId, result.readings);
+      await _repository.saveEfforts(rideId, efforts);
+      for (final effort in efforts) {
+        await _repository.saveMapCurve(effort.id, effort.mapCurve);
+      }
+    });
+
+    return ride;
   }
 
   /// Import a ZIP archive of TCX files.
   /// Returns results for each .tcx file (success or failure per file).
   /// Never throws — errors are collected per file.
-  Future<List<ImportResult>> importZip(File file, AutoLapConfig config) async {
+  Future<List<ImportResult>> importZip(
+    File file,
+    AutoLapConfig config, {
+    void Function(int done, int total)? onProgress,
+  }) async {
     final fileName = file.path.split(Platform.pathSeparator).last;
 
     if (file.lengthSync() > _maxFileSizeBytes) {
@@ -185,15 +201,18 @@ class ExportService {
       ];
     }
 
-    final tcxFiles = archive.files.where(
-      (f) => f.name.toLowerCase().endsWith('.tcx'),
-    );
+    final tcxFiles = archive.files
+        .where((f) => f.name.toLowerCase().endsWith('.tcx'))
+        .toList();
+    final total = tcxFiles.length;
 
     final results = <ImportResult>[];
     final tempDir = Directory.systemTemp.createTempSync('wattalizer_import_');
 
     try {
-      for (final entry in tcxFiles) {
+      onProgress?.call(0, total);
+      for (var i = 0; i < tcxFiles.length; i++) {
+        final entry = tcxFiles[i];
         final entryName = entry.name.split('/').last;
         final tempFile = File('${tempDir.path}/$entryName')
           ..writeAsBytesSync(entry.content as List<int>);
@@ -215,6 +234,7 @@ class ExportService {
             ),
           );
         }
+        onProgress?.call(i + 1, total);
       }
     } finally {
       tempDir.deleteSync(recursive: true);

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -4,7 +4,9 @@ import 'dart:io';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/core/error_types.dart';
 import 'package:wattalizer/domain/models/autolap_config.dart';
+import 'package:wattalizer/domain/services/export_service.dart';
 import 'package:wattalizer/presentation/providers/autolap_config_provider.dart';
 import 'package:wattalizer/presentation/providers/export_service_provider.dart';
 import 'package:wattalizer/presentation/providers/max_power_override_provider.dart';
@@ -189,6 +191,7 @@ class _ImportSection extends ConsumerStatefulWidget {
 
 class _ImportSectionState extends ConsumerState<_ImportSection> {
   bool _importing = false;
+  ({int done, int total})? _zipProgress;
 
   Future<void> _import() async {
     final result = await FilePicker.platform.pickFiles(
@@ -199,7 +202,10 @@ class _ImportSectionState extends ConsumerState<_ImportSection> {
     final file = result.files.first;
     if (file.path == null) return;
 
-    setState(() => _importing = true);
+    setState(() {
+      _importing = true;
+      _zipProgress = null;
+    });
 
     try {
       final export = ref.read(exportServiceProvider);
@@ -209,35 +215,144 @@ class _ImportSectionState extends ConsumerState<_ImportSection> {
       final ext = file.path!.split('.').last.toLowerCase();
 
       if (ext == 'zip') {
-        final results = await export.importZip(ioFile, config);
-        if (mounted) {
-          _showImportResults(
-            results.where((r) => r.ride != null).length,
-            results.where((r) => r.ride == null).length,
-          );
-        }
+        final results = await export.importZip(
+          ioFile,
+          config,
+          onProgress: (done, total) {
+            if (mounted) {
+              setState(() => _zipProgress = (done: done, total: total));
+            }
+          },
+        );
+        if (mounted) _showDetailedResults(results);
       } else {
-        await export.importTcx(ioFile, config);
-        if (mounted) _showImportResults(1, 0);
+        try {
+          final ride = await export.importTcx(ioFile, config);
+          if (mounted) {
+            _showDetailedResults(
+              [ImportResult(fileName: file.name, ride: ride)],
+            );
+          }
+        } on TcxImportError catch (e) {
+          if (mounted) {
+            _showDetailedResults([ImportResult(fileName: file.name, error: e)]);
+          }
+        }
       }
       ref.invalidate(rideListProvider);
     } on Exception catch (e) {
-      if (mounted) _showImportResults(0, 1, error: '$e');
+      if (mounted) {
+        _showDetailedResults([
+          ImportResult(
+            fileName: file.path!.split(Platform.pathSeparator).last,
+            error: TcxImportError(
+              fileName: file.path!.split(Platform.pathSeparator).last,
+              type: ImportErrorType.malformedXml,
+              detail: e.toString(),
+            ),
+          ),
+        ]);
+      }
     } finally {
-      if (mounted) setState(() => _importing = false);
+      if (mounted) {
+        setState(() {
+          _importing = false;
+          _zipProgress = null;
+        });
+      }
     }
   }
 
-  void _showImportResults(int imported, int errors, {String? error}) {
+  String _errorLabel(ImportErrorType type) => switch (type) {
+        ImportErrorType.malformedXml => 'Malformed XML',
+        ImportErrorType.noTrackpoints => 'No trackpoints',
+        ImportErrorType.noPowerData => 'No power data',
+        ImportErrorType.duplicateRide => 'Duplicate (already imported)',
+        ImportErrorType.fileTooLarge => 'File too large (>50 MB)',
+      };
+
+  void _showDetailedResults(List<ImportResult> results) {
+    final imported = results.where((r) => r.ride != null).length;
+    final errors = results.where((r) => r.error != null).length;
+
     unawaited(
       showDialog<void>(
         context: context,
         builder: (ctx) => AlertDialog(
           title: const Text('Import Results'),
-          content: Text(
-            error != null
-                ? 'Error: $error'
-                : '$imported imported, $errors errors',
+          content: SizedBox(
+            width: double.maxFinite,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (results.length > 1)
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 300),
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: results.length,
+                      itemBuilder: (_, i) {
+                        final r = results[i];
+                        final success = r.ride != null;
+                        return ListTile(
+                          dense: true,
+                          contentPadding: EdgeInsets.zero,
+                          leading: Icon(
+                            success ? Icons.check_circle : Icons.error_outline,
+                            color: success ? Colors.green : Colors.red,
+                            size: 20,
+                          ),
+                          title: Text(
+                            r.fileName,
+                            style: const TextStyle(fontSize: 13),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          trailing: success
+                              ? null
+                              : Text(
+                                  _errorLabel(r.error!.type),
+                                  style: TextStyle(
+                                    fontSize: 11,
+                                    color: Colors.red.shade300,
+                                  ),
+                                ),
+                        );
+                      },
+                    ),
+                  )
+                else if (results.length == 1) ...[
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(
+                        results.first.ride != null
+                            ? Icons.check_circle
+                            : Icons.error_outline,
+                        color: results.first.ride != null
+                            ? Colors.green
+                            : Colors.red,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          results.first.error != null
+                              ? _errorLabel(results.first.error!.type)
+                              : 'Imported successfully',
+                          style: const TextStyle(fontSize: 13),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+                const SizedBox(height: 12),
+                Text(
+                  '$imported imported, $errors error${errors == 1 ? '' : 's'}',
+                  style: Theme.of(ctx).textTheme.bodySmall,
+                ),
+              ],
+            ),
           ),
           actions: [
             TextButton(
@@ -252,10 +367,15 @@ class _ImportSectionState extends ConsumerState<_ImportSection> {
 
   @override
   Widget build(BuildContext context) {
+    final progress = _zipProgress;
+    final subtitle = progress != null
+        ? 'Importing... ${progress.done}/${progress.total}'
+        : 'TCX or ZIP files';
+
     return ListTile(
       leading: const Icon(Icons.file_upload),
       title: const Text('Import Rides'),
-      subtitle: const Text('TCX or ZIP files'),
+      subtitle: Text(subtitle),
       trailing: _importing
           ? const SizedBox(
               width: 20,

--- a/test/domain/export_service_test.dart
+++ b/test/domain/export_service_test.dart
@@ -302,6 +302,41 @@ void main() {
       expect(ride.startTime.hour, 10);
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // Persistence
+  // ---------------------------------------------------------------------------
+
+  group('persistence', () {
+    test('importTcx calls saveRide and insertReadings on success', () async {
+      final repo = _TrackingRepository();
+      final svc = ExportService(repository: repo, exportDirectory: tempDir);
+      final file = _writeTcxFile(tempDir, _validTcx());
+
+      await svc.importTcx(file, config);
+
+      expect(repo.saveRideCalls, 1);
+      expect(repo.insertReadingsCalls, 1);
+    });
+
+    test('importZip calls onProgress with (0,n)…(n,n) for n valid files',
+        () async {
+      final svc = makeService();
+      final zipFile = _makeZip(tempDir, {
+        'ride1.tcx': _validTcx(),
+        'ride2.tcx': _validTcxWithSpike(),
+      });
+
+      final progress = <(int, int)>[];
+      await svc.importZip(
+        zipFile,
+        config,
+        onProgress: (done, total) => progress.add((done, total)),
+      );
+
+      expect(progress, [(0, 2), (1, 2), (2, 2)]);
+    });
+  });
 }
 
 // =============================================================================
@@ -509,6 +544,25 @@ RideSummaryRow _makeSummaryRow({
         effortCount: 1,
       ),
     );
+
+// =============================================================================
+// Tracking repository (records call counts for persistence assertions)
+// =============================================================================
+
+class _TrackingRepository extends _FakeRepository {
+  int saveRideCalls = 0;
+  int insertReadingsCalls = 0;
+
+  @override
+  Future<void> saveRide(Ride ride) async => saveRideCalls++;
+
+  @override
+  Future<void> insertReadings(
+    String rideId,
+    List<SensorReading> readings,
+  ) async =>
+      insertReadingsCalls++;
+}
 
 // =============================================================================
 // Fake repository


### PR DESCRIPTION
Completes the final phase item. Fixes persistence bug where imported rides weren't saved to database. `importTcx` now atomically persists ride, readings, efforts, and map curves.

Adds `onProgress` callback to `importZip` for progress tracking. Settings import tile now displays live progress ("Importing... 3/12") and per-file results with ✅/❌ indicators and error labels.

281 tests passing. All phases complete.