### PR TITLE
Stream ZIP import instead of loading into RAM

### DIFF
--- a/lib/domain/services/export_service.dart
+++ b/lib/domain/services/export_service.dart
@@ -35,7 +35,6 @@ class ExportService {
   final Directory? _exportDirectory; // injectable for tests
 
   static const _uuid = Uuid();
-  static const int _maxFileSizeBytes = 50 * 1024 * 1024;
 
   /// Export ride to TCX file. Returns the file path.
   /// Throws [ExportError] on failure.
@@ -58,7 +57,7 @@ class ExportService {
     final fileName = file.path.split(Platform.pathSeparator).last;
 
     // Size check
-    if (file.lengthSync() > _maxFileSizeBytes) {
+    if (file.lengthSync() > 50 * 1024 * 1024) {
       throw TcxImportError(
         fileName: fileName,
         type: ImportErrorType.fileTooLarge,
@@ -172,23 +171,13 @@ class ExportService {
   }) async {
     final fileName = file.path.split(Platform.pathSeparator).last;
 
-    if (file.lengthSync() > _maxFileSizeBytes) {
-      return [
-        ImportResult(
-          fileName: fileName,
-          error: TcxImportError(
-            fileName: fileName,
-            type: ImportErrorType.fileTooLarge,
-            detail: 'ZIP file exceeds 50 MB limit',
-          ),
-        ),
-      ];
-    }
-
     late Archive archive;
+    InputFileStream? inputStream;
     try {
-      archive = ZipDecoder().decodeBytes(file.readAsBytesSync());
+      inputStream = InputFileStream(file.path);
+      archive = ZipDecoder().decodeStream(inputStream);
     } on Object catch (e) {
+      inputStream?.closeSync();
       return [
         ImportResult(
           fileName: fileName,
@@ -214,8 +203,10 @@ class ExportService {
       for (var i = 0; i < tcxFiles.length; i++) {
         final entry = tcxFiles[i];
         final entryName = entry.name.split('/').last;
-        final tempFile = File('${tempDir.path}/$entryName')
-          ..writeAsBytesSync(entry.content as List<int>);
+        final outStream = OutputFileStream('${tempDir.path}/$entryName');
+        entry.writeContent(outStream);
+        outStream.closeSync();
+        final tempFile = File('${tempDir.path}/$entryName');
 
         try {
           final ride = await importTcx(tempFile, config);
@@ -237,6 +228,7 @@ class ExportService {
         onProgress?.call(i + 1, total);
       }
     } finally {
+      inputStream.closeSync();
       tempDir.deleteSync(recursive: true);
     }
 

--- a/test/domain/export_service_test.dart
+++ b/test/domain/export_service_test.dart
@@ -267,23 +267,6 @@ void main() {
       expect(successes, hasLength(1));
       expect(failures, hasLength(1));
     });
-
-    test('ZIP file > 50MB → single error result', () async {
-      final svc = makeService();
-      final bigZip = File('${tempDir.path}/big.zip');
-      final sink = bigZip.openWrite();
-      final chunk = List.filled(1024 * 1024, 0x00);
-      for (var i = 0; i < 51; i++) {
-        sink.add(chunk);
-      }
-      await sink.flush();
-      await sink.close();
-
-      final results = await svc.importZip(bigZip, config);
-
-      expect(results, hasLength(1));
-      expect(results.first.error?.type, ImportErrorType.fileTooLarge);
-    });
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Removes 50 MB ZIP import size limit by replacing synchronous full-file read + decode with streaming via `InputFileStream` and `OutputFileStream` from `package:archive`. Entries are decompressed on-demand and written directly to temp files.

- Eliminates OOM risk on large bulk imports (no change to public API)
- Per-file TCX size check (50 MB) remains for individual imports
- Removes obsolete ZIP-level size check test