### PR TITLE
[Fix] ZIP import: support subdirectories and .tcx.gz files

### DIFF
--- a/lib/domain/services/export_service.dart
+++ b/lib/domain/services/export_service.dart
@@ -190,9 +190,10 @@ class ExportService {
       ];
     }
 
-    final tcxFiles = archive.files
-        .where((f) => f.name.toLowerCase().endsWith('.tcx'))
-        .toList();
+    final tcxFiles = archive.files.where((f) {
+      final n = f.name.toLowerCase();
+      return f.isFile && (n.endsWith('.tcx') || n.endsWith('.tcx.gz'));
+    }).toList();
     final total = tcxFiles.length;
 
     final results = <ImportResult>[];
@@ -203,10 +204,18 @@ class ExportService {
       for (var i = 0; i < tcxFiles.length; i++) {
         final entry = tcxFiles[i];
         final entryName = entry.name.split('/').last;
-        final outStream = OutputFileStream('${tempDir.path}/$entryName');
-        entry.writeContent(outStream);
-        outStream.closeSync();
-        final tempFile = File('${tempDir.path}/$entryName');
+        final File tempFile;
+        if (entryName.toLowerCase().endsWith('.gz')) {
+          final bytes =
+              const GZipDecoder().decodeBytes(entry.content as List<int>);
+          final tempName = entryName.replaceAll('.gz', '');
+          tempFile = File('${tempDir.path}/$tempName')..writeAsBytesSync(bytes);
+        } else {
+          final outStream = OutputFileStream('${tempDir.path}/$entryName');
+          entry.writeContent(outStream);
+          outStream.closeSync();
+          tempFile = File('${tempDir.path}/$entryName');
+        }
 
         try {
           final ride = await importTcx(tempFile, config);

--- a/test/domain/export_service_test.dart
+++ b/test/domain/export_service_test.dart
@@ -267,6 +267,31 @@ void main() {
       expect(successes, hasLength(1));
       expect(failures, hasLength(1));
     });
+
+    test('ZIP with file in subdirectory → 1 successful ImportResult', () async {
+      final svc = makeService();
+      final zipFile = _makeZipWithBytes(tempDir, {
+        'activities/ride.tcx': _validTcx().codeUnits,
+      });
+
+      final results = await svc.importZip(zipFile, config);
+
+      expect(results, hasLength(1));
+      expect(results.first.ride, isNotNull);
+    });
+
+    test('ZIP with .tcx.gz file → 1 successful ImportResult', () async {
+      final svc = makeService();
+      final gzBytes = const GZipEncoder().encode(_validTcx().codeUnits);
+      final zipFile = _makeZipWithBytes(tempDir, {
+        'activities/ride.tcx.gz': gzBytes,
+      });
+
+      final results = await svc.importZip(zipFile, config);
+
+      expect(results, hasLength(1));
+      expect(results.first.ride, isNotNull);
+    });
   });
 
   // ---------------------------------------------------------------------------
@@ -478,6 +503,15 @@ File _makeZip(Directory dir, Map<String, String> entries) {
   }
   final zipBytes = ZipEncoder().encode(archive);
   return File('${dir.path}/test.zip')..writeAsBytesSync(zipBytes);
+}
+
+File _makeZipWithBytes(Directory dir, Map<String, List<int>> entries) {
+  final archive = Archive();
+  for (final entry in entries.entries) {
+    archive.addFile(ArchiveFile(entry.key, entry.value.length, entry.value));
+  }
+  final zipBytes = ZipEncoder().encode(archive);
+  return File('${dir.path}/test_bytes.zip')..writeAsBytesSync(zipBytes);
 }
 
 // =============================================================================


### PR DESCRIPTION
Support Strava archive ZIP structure:
- Add f.isFile guard to skip directory entries
- Match both .tcx and .tcx.gz files
- Decompress .tcx.gz with GZipDecoder before importTcx
- Two new tests for subdirectory paths and gzip decompression