### PR TITLE
[Fix] BLE scan accumulation + UTC DateTime

### DIFF
--- a/lib/data/ble/ble_service_impl.dart
+++ b/lib/data/ble/ble_service_impl.dart
@@ -18,6 +18,9 @@ class BleServiceImpl implements domain.BleService {
   static const _hrMeasurementUuid = '00002a37-0000-1000-8000-00805f9b34fb';
   static const _cscMeasurementUuid = '00002a5b-0000-1000-8000-00805f9b34fb';
 
+  // --- Scan accumulator (dedup by deviceId, reset on each scan) ---
+  final Map<String, domain.DiscoveredDevice> _scanAccumulator = {};
+
   // --- Per-device state ---
   final Map<String, StreamSubscription<bool>> _connectionSubs = {};
   final Map<String, StreamController<domain.BleConnectionState>>
@@ -31,6 +34,7 @@ class BleServiceImpl implements domain.BleService {
 
   @override
   Stream<List<domain.DiscoveredDevice>> scanForDevices() {
+    _scanAccumulator.clear();
     unawaited(
       UniversalBle.startScan(
         scanFilter: ScanFilter(
@@ -40,9 +44,11 @@ class BleServiceImpl implements domain.BleService {
         // BLE not available (e.g. iOS simulator) — silently ignore.
       }),
     );
-    // universal_ble emits one device at a time. The provider layer
-    // accumulates into a list with dedup by deviceId.
-    return UniversalBle.scanStream.map((device) => [_mapScanResult(device)]);
+    return UniversalBle.scanStream.map((device) {
+      final mapped = _mapScanResult(device);
+      _scanAccumulator[mapped.deviceId] = mapped;
+      return _scanAccumulator.values.toList();
+    });
   }
 
   domain.DiscoveredDevice _mapScanResult(BleDevice device) {
@@ -56,6 +62,7 @@ class BleServiceImpl implements domain.BleService {
 
   @override
   void stopScan() {
+    _scanAccumulator.clear();
     unawaited(UniversalBle.stopScan());
   }
 

--- a/lib/domain/models/map_curve.dart
+++ b/lib/domain/models/map_curve.dart
@@ -37,7 +37,7 @@ class MapCurve {
       entityId: entityId,
       values: values,
       flags: flags,
-      computedAt: DateTime.now(),
+      computedAt: DateTime.now().toUtc(),
     );
   }
 

--- a/lib/domain/services/map_curve_calculator.dart
+++ b/lib/domain/services/map_curve_calculator.dart
@@ -16,7 +16,7 @@ class MapCurveCalculator {
         entityId: entityId,
         values: values,
         flags: flags,
-        computedAt: DateTime.now(),
+        computedAt: DateTime.now().toUtc(),
       );
     }
 

--- a/lib/presentation/screens/pdc_screen.dart
+++ b/lib/presentation/screens/pdc_screen.dart
@@ -78,7 +78,7 @@ class _PdcContent extends StatelessWidget {
       entityId: 'pdc',
       values: range.best.map((r) => r.power).toList(),
       flags: List.generate(90, (_) => const MapCurveFlags()),
-      computedAt: DateTime.now(),
+      computedAt: DateTime.now().toUtc(),
     );
   }
 }

--- a/lib/presentation/widgets/device_sheet.dart
+++ b/lib/presentation/widgets/device_sheet.dart
@@ -78,11 +78,7 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
     _scanSub = _bleService.scanForDevices().listen((devices) {
       if (!mounted) return;
       setState(() {
-        for (final d in devices) {
-          _scanResults
-            ..removeWhere((e) => e.deviceId == d.deviceId)
-            ..add(d);
-        }
+        _scanResults = List.from(devices);
       });
     });
   }
@@ -302,7 +298,7 @@ class _DeviceSheetContentState extends ConsumerState<_DeviceSheetContent> {
       deviceId: device.deviceId,
       displayName: device.name.isNotEmpty ? device.name : 'Unknown',
       supportedServices: device.advertisedServices,
-      lastConnected: DateTime.now(),
+      lastConnected: DateTime.now().toUtc(),
     );
     await repo.saveDevice(info);
     ref.invalidate(deviceListProvider);


### PR DESCRIPTION
## Summary
- BLE scan now accumulates discovered devices per session (full list emitted on each event, not single-device)
- All DateTime.now() calls for computedAt/lastConnected replaced with DateTime.now().toUtc()

## Changes
- ble_service_impl: _scanAccumulator field; scanForDevices clears and populates; stopScan clears
- device_sheet: simplified scan listener to direct assignment
- map_curve.dart, map_curve_calculator.dart, pdc_screen.dart: UTC timestamps

All 348 tests pass.