### PR TITLE
Remove debug banner from desktop builds

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -57,6 +57,7 @@ class SprintPowerAnalyzerApp extends ConsumerWidget {
 
     return MaterialApp(
       title: 'Wattalizer',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData.light(useMaterial3: true),
       darkTheme: ThemeData.dark(useMaterial3: true),
       themeMode: themeMode,


### PR DESCRIPTION
Suppress the Flutter debug banner overlay on all platforms, unblocking access to the AppBar menu button on desktop (macOS, Windows, Linux) where the banner was covering the dropdown.