### PR TITLE
[Fix] MAP plateau on efforts shorter than 90s

### DIFF
--- a/lib/domain/services/map_curve_calculator.dart
+++ b/lib/domain/services/map_curve_calculator.dart
@@ -38,12 +38,8 @@ class MapCurveCalculator {
       var bestHadNulls = false;
 
       if (d > n) {
-        // Duration longer than data — use entire data as single window.
-        final nonNull = countSum[n];
-        if (nonNull > 0) {
-          bestAvg = powerSum[n] / nonNull;
-          bestHadNulls = nonNull < n;
-        }
+        // Duration longer than data — no valid window exists.
+        continue;
       } else {
         // Slide window of size d across all positions.
         for (var end = d; end <= n; end++) {
@@ -107,11 +103,8 @@ class MapCurveCalculator {
       var bestHadNulls = false;
 
       if (d > n) {
-        final nonNull = _countSum[n];
-        if (nonNull > 0) {
-          bestAvg = _powerSum[n] / nonNull;
-          bestHadNulls = nonNull < n;
-        }
+        // Duration longer than data — no valid window exists.
+        continue;
       } else {
         for (var end = d; end <= n; end++) {
           final start = end - d;

--- a/lib/presentation/screens/ride_screen_chart.dart
+++ b/lib/presentation/screens/ride_screen_chart.dart
@@ -141,6 +141,28 @@ class RideChartMode extends StatelessWidget {
       );
     }
 
+    // Compute X max: highest duration with non-zero data across all curves
+    var maxX = 1.0;
+    for (final e in completedEfforts) {
+      for (var i = e.mapCurve.values.length - 1; i >= 0; i--) {
+        if (e.mapCurve.values[i] > 0) {
+          if (i + 1 > maxX) maxX = (i + 1).toDouble();
+          break;
+        }
+      }
+    }
+    if (liveCurve != null) {
+      for (var i = liveCurve.values.length - 1; i >= 0; i--) {
+        if (liveCurve.values[i] > 0) {
+          if (i + 1 > maxX) maxX = (i + 1).toDouble();
+          break;
+        }
+      }
+    }
+    if (histRange != null && histRange.best.length > maxX) {
+      maxX = histRange.best.length.toDouble();
+    }
+
     // Compute Y max across all data
     var maxY = 100.0;
     if (histRange != null) {
@@ -164,7 +186,7 @@ class RideChartMode extends StatelessWidget {
       lineBarsData: lines,
       betweenBarsData: betweenBars,
       minX: 1,
-      maxX: 90,
+      maxX: maxX,
       minY: 0,
       maxY: maxY,
       gridData: FlGridData(
@@ -231,10 +253,10 @@ class RideChartMode extends StatelessWidget {
     double strokeWidth = 2,
   }) {
     return LineChartBarData(
-      spots: List.generate(
-        values.length,
-        (i) => FlSpot((i + 1).toDouble(), values[i]),
-      ),
+      spots: [
+        for (var i = 0; i < values.length; i++)
+          if (values[i] > 0) FlSpot((i + 1).toDouble(), values[i]),
+      ],
       isCurved: true,
       curveSmoothness: 0.2,
       color: color,
@@ -249,10 +271,11 @@ class RideChartMode extends StatelessWidget {
     required HistoricalRange? histRange,
   }) {
     return LineChartBarData(
-      spots: List.generate(
-        90,
-        (i) => FlSpot((i + 1).toDouble(), liveCurve.values[i]),
-      ),
+      spots: [
+        for (var i = 0; i < liveCurve.values.length; i++)
+          if (liveCurve.values[i] > 0)
+            FlSpot((i + 1).toDouble(), liveCurve.values[i]),
+      ],
       isCurved: true,
       curveSmoothness: 0.2,
       gradient: const LinearGradient(

--- a/lib/presentation/widgets/map_curve_chart.dart
+++ b/lib/presentation/widgets/map_curve_chart.dart
@@ -103,7 +103,7 @@ class MapCurveChart extends StatelessWidget {
           lineBarsData: lineBars,
           betweenBarsData: betweenBars,
           minX: 1,
-          maxX: 90,
+          maxX: spots.isEmpty ? 90 : spots.last.x,
           minY: 0,
           maxY: maxY,
           gridData: const FlGridData(show: false),

--- a/test/domain/map_curve_calculator_test.dart
+++ b/test/domain/map_curve_calculator_test.dart
@@ -44,9 +44,9 @@ void main() {
       expect(curve.values[5], closeTo(500.0, 0.01));
       expect(curve.flags[5].hadNulls, true);
 
-      // Durations 7..90: d > n, use entire data → same as 6s = 500
+      // Durations 7..90: d > n, no valid window → 0
       for (var i = 6; i < 90; i++) {
-        expect(curve.values[i], closeTo(500.0, 0.01));
+        expect(curve.values[i], 0.0);
       }
     });
 
@@ -118,9 +118,9 @@ void main() {
       for (var i = 0; i < 10; i++) {
         expect(curve.values[i], closeTo(400.0, 0.001));
       }
-      // Duration 11..90: d > n, uses all 10 readings → still 400
+      // Duration 11..90: d > n, no valid window → 0
       for (var i = 10; i < 90; i++) {
-        expect(curve.values[i], closeTo(400.0, 0.001));
+        expect(curve.values[i], 0.0);
       }
     });
 
@@ -203,8 +203,8 @@ void main() {
       final curve = calc.updateLive(_r(0, power: 500), 'test');
       // After reset, only 1 reading: 1s best = 500
       expect(curve.values[0], closeTo(500.0, 0.001));
-      // 2s: d > n, uses all data → 500
-      expect(curve.values[1], closeTo(500.0, 0.001));
+      // 2s: d > n, no valid window → 0
+      expect(curve.values[1], 0.0);
     });
 
     test('live output is monotonically non-increasing after each call', () {


### PR DESCRIPTION
## Problem
When an effort is shorter than 90s, the MAP curve is artificially stretched to fill the full 1–90s duration, with values remaining constant from effort end to 90s.

## Root Cause
The MAP calculator was filling slots for durations d > effort_length with the "average of all readings" (the full-effort MAP value), creating a false plateau.

## Solution
1. **Calculator**: Remove the `d > n` branch that filled longer durations; leave them as 0.
2. **Charts**: Filter zero values and use dynamic maxX based on actual data extent.

All 365 tests pass.