### PR TITLE
Extend MAP curve to 90s with sprint shading

### DIFF
--- a/lib/domain/services/effort_manager.dart
+++ b/lib/domain/services/effort_manager.dart
@@ -27,7 +27,7 @@ class EffortManager {
     required List<SensorReading> rideReadings,
     Effort? previousEffort,
   }) {
-    final slice = rideReadings
+    final summarySlice = rideReadings
         .where(
           (r) =>
               r.timestamp.inSeconds >= startOffset &&
@@ -35,9 +35,19 @@ class EffortManager {
         )
         .toList();
 
+    // MAP curve uses up to 90s from effort start to capture recovery taper
+    final curveEndOffset = startOffset + 89;
+    final curveSlice = rideReadings
+        .where(
+          (r) =>
+              r.timestamp.inSeconds >= startOffset &&
+              r.timestamp.inSeconds <= curveEndOffset,
+        )
+        .toList();
+
     final effortId = _uuid.v4();
-    final summary = SummaryCalculator.computeEffortSummary(slice);
-    final mapCurve = MapCurveCalculator.computeBatch(slice, effortId);
+    final summary = SummaryCalculator.computeEffortSummary(summarySlice);
+    final mapCurve = MapCurveCalculator.computeBatch(curveSlice, effortId);
 
     final restSincePrevious =
         previousEffort != null ? startOffset - previousEffort.endOffset : null;

--- a/lib/domain/services/ride_session_manager.dart
+++ b/lib/domain/services/ride_session_manager.dart
@@ -196,6 +196,30 @@ class RideSessionManager {
     final finalEvent = _detector.endRide(_currentOffsetSeconds);
     _handleEvent(finalEvent);
 
+    // Recompute MAP curves with full readings (90s window from effort start)
+    for (var i = 0; i < _efforts.length; i++) {
+      final e = _efforts[i];
+      final curveEnd = e.startOffset + 89;
+      final curveSlice = _readings
+          .where(
+            (r) =>
+                r.timestamp.inSeconds >= e.startOffset &&
+                r.timestamp.inSeconds <= curveEnd,
+          )
+          .toList();
+      final newCurve = MapCurveCalculator.computeBatch(curveSlice, e.id);
+      _efforts[i] = Effort(
+        id: e.id,
+        rideId: e.rideId,
+        effortNumber: e.effortNumber,
+        startOffset: e.startOffset,
+        endOffset: e.endOffset,
+        type: e.type,
+        summary: e.summary,
+        mapCurve: newCurve,
+      );
+    }
+
     final endTime = DateTime.now().toUtc();
     final summary = SummaryCalculator.computeRideSummary(_readings, _efforts);
 

--- a/lib/presentation/screens/ride_screen_chart.dart
+++ b/lib/presentation/screens/ride_screen_chart.dart
@@ -120,13 +120,34 @@ class RideChartMode extends StatelessWidget {
       );
     }
 
-    // Previous session efforts — faded
+    // Previous session efforts — faded full curve + sprint region fill
     for (final effort in completedEfforts) {
       lines.add(
         _curveLine(
           effort.mapCurve.values,
           cs.onSurface.withValues(alpha: 0.25),
           strokeWidth: 1.5,
+        ),
+      );
+      final dur = effort.summary.durationSeconds;
+      lines.add(
+        LineChartBarData(
+          spots: [
+            for (var i = 0;
+                i < effort.mapCurve.values.length && (i + 1) <= dur;
+                i++)
+              if (effort.mapCurve.values[i] > 0)
+                FlSpot((i + 1).toDouble(), effort.mapCurve.values[i]),
+          ],
+          isCurved: true,
+          curveSmoothness: 0.2,
+          color: Colors.transparent,
+          barWidth: 0,
+          dotData: const FlDotData(show: false),
+          belowBarData: BarAreaData(
+            show: true,
+            color: cs.onSurface.withValues(alpha: 0.06),
+          ),
         ),
       );
     }
@@ -141,27 +162,7 @@ class RideChartMode extends StatelessWidget {
       );
     }
 
-    // Compute X max: highest duration with non-zero data across all curves
-    var maxX = 1.0;
-    for (final e in completedEfforts) {
-      for (var i = e.mapCurve.values.length - 1; i >= 0; i--) {
-        if (e.mapCurve.values[i] > 0) {
-          if (i + 1 > maxX) maxX = (i + 1).toDouble();
-          break;
-        }
-      }
-    }
-    if (liveCurve != null) {
-      for (var i = liveCurve.values.length - 1; i >= 0; i--) {
-        if (liveCurve.values[i] > 0) {
-          if (i + 1 > maxX) maxX = (i + 1).toDouble();
-          break;
-        }
-      }
-    }
-    if (histRange != null && histRange.best.length > maxX) {
-      maxX = histRange.best.length.toDouble();
-    }
+    const maxX = 90.0;
 
     // Compute Y max across all data
     var maxY = 100.0;

--- a/lib/presentation/widgets/effort_card.dart
+++ b/lib/presentation/widgets/effort_card.dart
@@ -71,7 +71,11 @@ class EffortCard extends StatelessWidget {
           SizedBox(
             width: 80,
             height: 40,
-            child: MapCurveChart(curve: effort.mapCurve, compact: true),
+            child: MapCurveChart(
+              curve: effort.mapCurve,
+              effortDuration: effort.summary.durationSeconds,
+              compact: true,
+            ),
           ),
         ],
       ),
@@ -92,6 +96,7 @@ class EffortCard extends StatelessWidget {
           MapCurveChart(
             curve: effort.mapCurve,
             historicalRange: historicalRange,
+            effortDuration: effort.summary.durationSeconds,
           ),
           const SizedBox(height: 12),
           _StatRow(label: 'Duration', value: _dur(s.durationSeconds)),

--- a/lib/presentation/widgets/map_curve_chart.dart
+++ b/lib/presentation/widgets/map_curve_chart.dart
@@ -12,6 +12,7 @@ class MapCurveChart extends StatelessWidget {
     required this.curve,
     this.historicalRange,
     this.provenanceRecords,
+    this.effortDuration,
     this.compact = false,
     super.key,
   });
@@ -19,6 +20,10 @@ class MapCurveChart extends StatelessWidget {
   final MapCurve curve;
   final HistoricalRange? historicalRange;
   final List<DurationRecord>? provenanceRecords;
+
+  /// Sprint portion duration in seconds. When provided (non-compact mode),
+  /// the sprint region is shaded; the rest of the 90s curve is unshaded.
+  final int? effortDuration;
   final bool compact;
 
   @override
@@ -52,8 +57,10 @@ class MapCurveChart extends StatelessWidget {
       color: colorScheme.primary,
       barWidth: compact ? 1.5 : 2.5,
       dotData: const FlDotData(show: false),
+      // Compact sparkline: fill the whole curve. Non-compact: no fill on the
+      // line itself; sprint region is filled separately below.
       belowBarData: BarAreaData(
-        show: !compact,
+        show: compact,
         color: colorScheme.primary.withValues(alpha: 0.1),
       ),
     );
@@ -96,6 +103,27 @@ class MapCurveChart extends StatelessWidget {
       );
     }
 
+    // Sprint region fill: invisible line with fill up to effortDuration
+    if (effortDuration != null && !compact) {
+      final sprintSpots = spots.where((s) => s.x <= effortDuration!).toList();
+      if (sprintSpots.isNotEmpty) {
+        lineBars.add(
+          LineChartBarData(
+            spots: sprintSpots,
+            isCurved: true,
+            curveSmoothness: 0.2,
+            color: Colors.transparent,
+            barWidth: 0,
+            dotData: const FlDotData(show: false),
+            belowBarData: BarAreaData(
+              show: true,
+              color: colorScheme.primary.withValues(alpha: 0.1),
+            ),
+          ),
+        );
+      }
+    }
+
     return SizedBox(
       height: compact ? 48 : 200,
       child: LineChart(
@@ -103,7 +131,7 @@ class MapCurveChart extends StatelessWidget {
           lineBarsData: lineBars,
           betweenBarsData: betweenBars,
           minX: 1,
-          maxX: spots.isEmpty ? 90 : spots.last.x,
+          maxX: 90,
           minY: 0,
           maxY: maxY,
           gridData: const FlGridData(show: false),

--- a/test/domain/effort_manager_test.dart
+++ b/test/domain/effort_manager_test.dart
@@ -89,6 +89,38 @@ void main() {
       expect(effort.mapCurve.entityId, effort.id);
     });
 
+    test('MAP curve extends beyond effort boundary when ride data is available',
+        () {
+      // Effort is t=1..2, but ride data continues to t=5 (within 90s window)
+      final rideReadings = [
+        _r(0, power: 100),
+        _r(1, power: 800),
+        _r(2, power: 900),
+        _r(3, power: 300), // recovery — outside effort boundary
+        _r(4, power: 250),
+        _r(5, power: 200),
+      ];
+
+      final effort = manager.createEffort(
+        rideId: 'ride1',
+        effortNumber: 1,
+        startOffset: 1,
+        endOffset: 2,
+        type: EffortType.auto,
+        rideReadings: rideReadings,
+      );
+
+      // Summary still uses effort-bounded slice (t=1..2)
+      expect(effort.summary.durationSeconds, 2);
+      expect(effort.summary.avgPower, closeTo(850.0, 0.001));
+
+      // MAP curve extends beyond endOffset=2 using recovery data
+      // 3s best = best 3s window: (800+900+300)/3 ≈ 666.7
+      expect(effort.mapCurve.values[2], greaterThan(0));
+      // 4s best = (800+900+300+250)/4 = 562.5
+      expect(effort.mapCurve.values[3], greaterThan(0));
+    });
+
     test('restSincePrevious is null for first effort', () {
       final readings = List.generate(5, (i) => _r(i, power: 400));
       final effort = manager.createEffort(

--- a/test/domain/ride_session_manager_test.dart
+++ b/test/domain/ride_session_manager_test.dart
@@ -499,6 +499,64 @@ void main() {
         final ride = await mgr.end();
         expect(ride.efforts, hasLength(1));
       });
+
+      test('MAP curves recomputed with extended 90s window at ride end',
+          () async {
+        final sc = StreamController<RawSensorData>();
+        final mgr = makeManager()..start(sc.stream);
+
+        // Build baseline: 5 ticks at 100W
+        for (var i = 0; i < 5; i++) {
+          mgr.currentBin.add(
+            RawSensorData(
+              receivedAt: DateTime.now(),
+              power: const PowerData(instantaneousPower: 100),
+            ),
+          );
+          mgr.processTick();
+        }
+
+        // Sprint: 5 ticks at 350W → effort detected
+        for (var i = 0; i < 5; i++) {
+          mgr.currentBin.add(
+            RawSensorData(
+              receivedAt: DateTime.now(),
+              power: const PowerData(instantaneousPower: 350),
+            ),
+          );
+          mgr.processTick();
+        }
+
+        // Drop below end threshold → effort ends
+        for (var i = 0; i < 2; i++) {
+          mgr.currentBin.add(
+            RawSensorData(
+              receivedAt: DateTime.now(),
+              power: const PowerData(instantaneousPower: 50),
+            ),
+          );
+          mgr.processTick();
+        }
+
+        // Recovery: 20 more ticks at 150W (data beyond effort boundary)
+        for (var i = 0; i < 20; i++) {
+          mgr.currentBin.add(
+            RawSensorData(
+              receivedAt: DateTime.now(),
+              power: const PowerData(instantaneousPower: 150),
+            ),
+          );
+          mgr.processTick();
+        }
+
+        final ride = await mgr.end();
+        expect(ride.efforts, hasLength(1));
+
+        // After recompute, curve includes recovery data beyond the ~5s sprint.
+        // Index 6 (7s window) must be non-zero since recovery readings exist.
+        final curve = ride.efforts.first.mapCurve;
+        expect(curve.values[6], greaterThan(0));
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary
- **effort_manager**: split slice so summary uses effort boundaries (unchanged) and MAP curve extends to 90s from effort start for recovery taper
- **ride_session_manager**: recompute all MAP curves in end() once full readings available
- **map_curve_chart**: rename maxDuration→effortDuration; draw full 90s curve; shade sprint region only
- **effort_card, ride_screen_chart**: pass effortDuration and add subtle sprint fill for completed efforts

Effort summary stats (avgPower, durationSeconds, peakPower) remain based on detected sprint boundaries. Short efforts now show natural taper to 90s instead of plateau.

All tests pass (367 total).