### PR TITLE
[Fix] fit.gz in zip routes to importFit

### DIFF
--- a/lib/domain/services/export_service.dart
+++ b/lib/domain/services/export_service.dart
@@ -229,7 +229,7 @@ class ExportService {
         final lowerName = entryName.toLowerCase();
         try {
           final Ride ride;
-          if (lowerName.endsWith('.fit')) {
+          if (lowerName.endsWith('.fit') || lowerName.endsWith('.fit.gz')) {
             ride = await importFit(tempFile, config);
           } else {
             ride = await importTcx(tempFile, config);


### PR DESCRIPTION
Fix format dispatch for .fit.gz files in zip bundles. The condition was checking original entryName (still ending in .gz), so .fit.gz files fell through to importTcx instead of importFit, causing 'invalid file format' errors. One-line fix: check for both .fit and .fit.gz extensions.