### PR TITLE
Add ability to remove individual efforts from a ride

### DIFF
--- a/lib/domain/services/effort_manager.dart
+++ b/lib/domain/services/effort_manager.dart
@@ -127,4 +127,29 @@ class EffortManager {
 
     return efforts;
   }
+
+  /// Returns a new list with the effort matching [effortNumber] removed.
+  /// Remaining efforts are renumbered from 1 and restSincePrevious is
+  /// recalculated from the adjacent offsets.
+  static List<Effort> removeEffort(List<Effort> efforts, int effortNumber) {
+    final remaining =
+        efforts.where((e) => e.effortNumber != effortNumber).toList();
+    return [
+      for (var i = 0; i < remaining.length; i++)
+        Effort(
+          id: remaining[i].id,
+          rideId: remaining[i].rideId,
+          effortNumber: i + 1,
+          startOffset: remaining[i].startOffset,
+          endOffset: remaining[i].endOffset,
+          type: remaining[i].type,
+          summary: remaining[i].summary.copyWith(
+                restSincePrevious: i == 0
+                    ? null
+                    : remaining[i].startOffset - remaining[i - 1].endOffset,
+              ),
+          mapCurve: remaining[i].mapCurve,
+        ),
+    ];
+  }
 }

--- a/lib/presentation/screens/ride_detail_screen.dart
+++ b/lib/presentation/screens/ride_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:share_plus/share_plus.dart';
 import 'package:wattalizer/domain/models/historical_range.dart';
 import 'package:wattalizer/domain/models/ride.dart';
 import 'package:wattalizer/domain/models/ride_summary.dart';
+import 'package:wattalizer/domain/services/effort_manager.dart';
 import 'package:wattalizer/domain/services/export_service.dart';
 import 'package:wattalizer/presentation/providers/all_tags_provider.dart';
 import 'package:wattalizer/presentation/providers/historical_range_provider.dart';
@@ -129,6 +130,7 @@ class _DetailViewState extends State<_DetailView> {
                           ? null
                           : e.effortNumber;
                     }),
+                    onDelete: () => _deleteEffort(ride, e.effortNumber),
                   ),
                 ),
               ),
@@ -197,6 +199,60 @@ class _DetailViewState extends State<_DetailView> {
     widget.ref.invalidate(rideListProvider);
     if (!mounted) return;
     Navigator.pop(context);
+  }
+
+  Future<void> _deleteEffort(Ride ride, int effortNumber) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text('Remove Effort $effortNumber?'),
+        content: const Text('This cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+
+    final updated = EffortManager.removeEffort(ride.efforts, effortNumber);
+    final repo = widget.ref.read(rideRepositoryProvider);
+    await repo.saveEfforts(ride.id, updated);
+    final s = ride.summary;
+    await repo.updateRide(
+      ride.copyWith(
+        efforts: updated,
+        summary: RideSummary(
+          durationSeconds: s.durationSeconds,
+          activeDurationSeconds: s.activeDurationSeconds,
+          avgPower: s.avgPower,
+          maxPower: s.maxPower,
+          readingCount: s.readingCount,
+          effortCount: updated.length,
+          avgHeartRate: s.avgHeartRate,
+          maxHeartRate: s.maxHeartRate,
+          avgCadence: s.avgCadence,
+          avgLeftRightBalance: s.avgLeftRightBalance,
+        ),
+      ),
+    );
+
+    widget.ref
+      ..invalidate(rideDetailProvider(ride.id))
+      ..invalidate(rideListProvider)
+      ..invalidate(historicalRangeProvider);
+
+    setState(() => _expandedEffort = null);
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Effort $effortNumber removed')),
+    );
   }
 
   static String _formatDate(DateTime dt) {

--- a/lib/presentation/widgets/effort_card.dart
+++ b/lib/presentation/widgets/effort_card.dart
@@ -11,6 +11,7 @@ class EffortCard extends StatelessWidget {
     this.historicalRange,
     this.isExpanded = false,
     this.onToggle,
+    this.onDelete,
     super.key,
   });
 
@@ -18,6 +19,7 @@ class EffortCard extends StatelessWidget {
   final HistoricalRange? historicalRange;
   final bool isExpanded;
   final VoidCallback? onToggle;
+  final VoidCallback? onDelete;
 
   @override
   Widget build(BuildContext context) {
@@ -88,9 +90,24 @@ class EffortCard extends StatelessWidget {
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            'Effort ${effort.effortNumber}',
-            style: const TextStyle(fontWeight: FontWeight.w600, fontSize: 16),
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  'Effort ${effort.effortNumber}',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
+                  ),
+                ),
+              ),
+              if (onDelete != null)
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  tooltip: 'Remove effort',
+                  onPressed: onDelete,
+                ),
+            ],
           ),
           const SizedBox(height: 12),
           MapCurveChart(


### PR DESCRIPTION
Allows users to manually remove false-positive efforts after running auto-detection (e.g., "Broad"). Users expand an effort card and tap the trash icon to remove it, triggering a confirmation dialog.

Implements:
- `EffortManager.removeEffort()` — filters effort from list, renumbers remaining 1-N, recalculates `restSincePrevious` from adjacent offsets
- Delete button in expanded `EffortCard` (trash icon next to title)
- Handler in `RideDetailScreen` that calls `saveEfforts()` + `updateRide()` atomically and invalidates affected providers

All 375 tests pass. No new repository methods or database changes.