### PR TITLE
Top-10 historical envelope band

### DIFF
--- a/lib/domain/services/historical_range_calculator.dart
+++ b/lib/domain/services/historical_range_calculator.dart
@@ -3,13 +3,18 @@ import 'package:wattalizer/domain/models/historical_range.dart';
 import 'package:wattalizer/domain/models/history_span.dart';
 
 class HistoricalRangeCalculator {
-  /// Compute best and worst envelopes with provenance from a list of
-  /// effort-level MAP curves in a single pass.
+  /// Compute best and top-N envelopes with provenance from a list of
+  /// effort-level MAP curves.
   ///
-  /// Performance: O(n × 90) where n = number of efforts. Single pass.
+  /// [topN] controls the lower bound of the envelope: the lower bound at each
+  /// duration is the Nth-best value (default 10). If fewer than [topN] efforts
+  /// exist, the lower bound is the weakest available value.
+  ///
+  /// Performance: O(n × 90 × topN) — negligible for small topN.
   HistoricalRange compute(
     List<MapCurveWithProvenance> effortCurves, {
     HistorySpan span = HistorySpan.allTime,
+    int topN = 10,
   }) {
     const kCount = 90;
 
@@ -33,28 +38,42 @@ class HistoricalRangeCalculator {
       );
     }
 
-    // Initialize best/worst from the first curve.
-    final first = effortCurves.first;
-    final bestPower = List<double>.from(first.curve.values);
-    final worstPower = List<double>.from(first.curve.values);
-    final bestProv = List<MapCurveWithProvenance>.filled(kCount, first);
-    final worstProv = List<MapCurveWithProvenance>.filled(kCount, first);
+    // For each duration: maintain top-N (power, provenance) pairs, sorted desc.
+    final topLists = List<List<(double, MapCurveWithProvenance)>>.generate(
+      kCount,
+      (_) => [],
+    );
 
-    // Single pass: for each duration, find max (best) and min (worst).
-    for (var e = 1; e < effortCurves.length; e++) {
-      final curve = effortCurves[e];
+    for (final curve in effortCurves) {
       for (var i = 0; i < kCount; i++) {
         final v = curve.curve.values[i];
-        if (v > bestPower[i]) {
-          bestPower[i] = v;
-          bestProv[i] = curve;
+        final list = topLists[i];
+        var inserted = false;
+        for (var j = 0; j < list.length; j++) {
+          if (v > list[j].$1) {
+            list.insert(j, (v, curve));
+            inserted = true;
+            break;
+          }
         }
-        if (v < worstPower[i]) {
-          worstPower[i] = v;
-          worstProv[i] = curve;
-        }
+        if (!inserted && list.length < topN) list.add((v, curve));
+        if (list.length > topN) list.removeLast();
       }
     }
+
+    // Best = highest value; worst = Nth-best (bottom of top-N band).
+    final bestPower =
+        List<double>.generate(kCount, (i) => topLists[i].first.$1);
+    final worstPower =
+        List<double>.generate(kCount, (i) => topLists[i].last.$1);
+    final bestProv = List<MapCurveWithProvenance>.generate(
+      kCount,
+      (i) => topLists[i].first.$2,
+    );
+    final worstProv = List<MapCurveWithProvenance>.generate(
+      kCount,
+      (i) => topLists[i].last.$2,
+    );
 
     // Monotonicity enforcement: sweep right-to-left on both envelopes.
     // If values[i] < values[i+1], bump values[i] to values[i+1] and

--- a/test/domain/historical_range_calculator_test.dart
+++ b/test/domain/historical_range_calculator_test.dart
@@ -201,6 +201,77 @@ void main() {
       },
     );
 
+    test('topN=2: worst is 2nd-best, not all-time worst', () {
+      // 3 efforts at 1s: 1000, 800, 200 → top2 = [1000, 800]; worst = 800
+      final e1 = _curve(
+        values5: [1000, 900, 800, 700, 600],
+        effortId: 'e1',
+        rideId: 'r1',
+      );
+      final e2 = _curve(
+        values5: [800, 750, 700, 650, 600],
+        effortId: 'e2',
+        rideId: 'r1',
+      );
+      final e3 = _curve(
+        values5: [200, 190, 180, 170, 160],
+        effortId: 'e3',
+        rideId: 'r1',
+      );
+
+      final result = calculator.compute([e1, e2, e3], topN: 2);
+
+      expect(result.best[0].power, closeTo(1000, 0.001));
+      expect(result.best[0].effortId, 'e1');
+      // worst = 2nd-best = 800, not 200
+      expect(result.worst[0].power, closeTo(800, 0.001));
+      expect(result.worst[0].effortId, 'e2');
+    });
+
+    test('fewer efforts than topN: worst = weakest available', () {
+      final e1 = _curve(
+        values5: [1000, 900, 800, 700, 600],
+        effortId: 'e1',
+        rideId: 'r1',
+      );
+      final e2 = _curve(
+        values5: [800, 750, 700, 650, 600],
+        effortId: 'e2',
+        rideId: 'r1',
+      );
+
+      // Default topN=10 but only 2 efforts → worst = 2nd-best (e2)
+      final result = calculator.compute([e1, e2]);
+
+      expect(result.best[0].power, closeTo(1000, 0.001));
+      expect(result.worst[0].power, closeTo(800, 0.001));
+      expect(result.worst[0].effortId, 'e2');
+    });
+
+    test('default topN=10: with 5 efforts worst = 5th-best', () {
+      final curves = List.generate(
+        5,
+        (i) => _curve(
+          values5: [
+            (1000 - i * 100).toDouble(),
+            (900 - i * 100).toDouble(),
+            (800 - i * 100).toDouble(),
+            (700 - i * 100).toDouble(),
+            (600 - i * 100).toDouble(),
+          ],
+          effortId: 'e$i',
+          rideId: 'r1',
+        ),
+      );
+
+      // topN=10, only 5 efforts → worst = weakest of the 5 = e4 with 600
+      final result = calculator.compute(curves);
+
+      expect(result.best[0].power, closeTo(1000, 0.001));
+      expect(result.worst[0].power, closeTo(600, 0.001));
+      expect(result.worst[0].effortId, 'e4');
+    });
+
     test('durationSeconds in records matches index+1', () {
       final c = _curve(
         values5: [1000, 900, 800, 700, 600],


### PR DESCRIPTION
Replace the all-time worst with the 10th-best value as the lower bound of the historical envelope. This makes the band reflect top performances rather than stretching near zero from poor efforts.

Changes:
- HistoricalRangeCalculator now tracks top-N values per duration (default 10)
- Lower bound is the Nth-best rather than minimum
- All existing tests pass; added 3 new tests for top-N behavior