### PR TITLE
Cap effort duration at 90s

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,3 +1,7 @@
+/// Hard cap on effort duration in seconds. MAP curve only covers 1–90s,
+/// so any effort longer than this provides no additional data.
+const int kMaxEffortSeconds = 90;
+
 /// MAP curve duration range: 1 to 90 seconds inclusive.
 const List<int> kMapDurations = [
   1,

--- a/lib/domain/services/autolap_detector.dart
+++ b/lib/domain/services/autolap_detector.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:wattalizer/core/constants.dart';
 import 'package:wattalizer/domain/events/autolap_events.dart';
 import 'package:wattalizer/domain/models/autolap_config.dart';
 import 'package:wattalizer/domain/models/sensor_reading.dart';
@@ -98,6 +99,28 @@ class AutoLapDetector {
       case AutoLapState.inEffort:
         if (power != null) _peakWatts = max(_peakWatts ?? 0, power);
         _inEffortTrailing.add(power);
+
+        final elapsed = offset - _tentativeStartOffset;
+        if (elapsed >= kMaxEffortSeconds) {
+          _state = AutoLapState.idle;
+          final preEffortBaselineCap = _preEffortBaseline.average;
+          final peakTrailingAvgCap = _inEffortTrailing.average;
+          final peakCap = _peakWatts ?? 0;
+          _preEffortBaseline.clear();
+          _inEffortTrailing.clear();
+          _peakWatts = null;
+          return EffortEndedEvent(
+            startOffset: _tentativeStartOffset,
+            endOffset: offset,
+            isManual: false,
+            wasTooShort: false,
+            wasTooWeak:
+                config.minPeakWatts != null && peakCap < config.minPeakWatts!,
+            peakWatts: peakCap,
+            preEffortBaseline: preEffortBaselineCap,
+            peakTrailingAvg: peakTrailingAvgCap,
+          );
+        }
 
         if (power != null &&
             power < _inEffortTrailing.average - config.endDeltaWatts) {

--- a/test/domain/autolap_detector_test.dart
+++ b/test/domain/autolap_detector_test.dart
@@ -391,6 +391,66 @@ void main() {
     });
   });
 
+  group('AutoLapDetector — 90s cap', () {
+    test('power stays high for exactly 90s → effort ends at offset 90', () {
+      final detector = AutoLapDetector(_cfg(startConfirm: 1, endConfirm: 5));
+
+      // Cold start: offset 0 starts effort immediately
+      var ev = detector.processReading(_r(0, power: 400));
+      expect(ev, isA<EffortStartedEvent>());
+      expect((ev! as EffortStartedEvent).startOffset, 0);
+
+      // Readings t=1..89: high power, no end
+      for (var t = 1; t < 90; t++) {
+        ev = detector.processReading(_r(t, power: 400));
+        expect(ev, isNull, reason: 'should not end at t=$t');
+      }
+      expect(detector.currentState, AutoLapState.inEffort);
+
+      // t=90: elapsed = 90-0 = 90 → force end
+      ev = detector.processReading(_r(90, power: 400));
+      expect(ev, isA<EffortEndedEvent>());
+      final ended = ev! as EffortEndedEvent;
+      expect(ended.startOffset, 0);
+      expect(ended.endOffset, 90);
+      expect(ended.wasTooShort, false);
+      expect(ended.isManual, false);
+      expect(detector.currentState, AutoLapState.idle);
+    });
+
+    test('power stays high for 91s → effort ends at offset 90, not 91', () {
+      // Use endConfirm=5 to ensure natural end-detection never fires.
+      final detector = AutoLapDetector(_cfg(startConfirm: 1, endConfirm: 5));
+
+      for (var t = 0; t < 90; t++) {
+        detector.processReading(_r(t, power: 400));
+      }
+
+      // Cap fires at t=90; endOffset must be 90, not 91
+      final ev = detector.processReading(_r(90, power: 400));
+      expect(ev, isA<EffortEndedEvent>());
+      expect((ev! as EffortEndedEvent).endOffset, 90);
+    });
+
+    test('natural end before 90s still works normally', () {
+      final detector = AutoLapDetector(_cfg(startConfirm: 1, endConfirm: 1));
+
+      for (var t = 0; t < 5; t++) {
+        detector.processReading(_r(t, power: 100));
+      }
+      detector.processReading(_r(5, power: 400)); // → inEffort
+
+      for (var t = 6; t < 30; t++) {
+        detector.processReading(_r(t, power: 400));
+      }
+      // Power drops well before 90s
+      final ev = detector.processReading(_r(30, power: 90));
+      expect(ev, isA<EffortEndedEvent>());
+      expect((ev! as EffortEndedEvent).endOffset, 30);
+      expect(detector.currentState, AutoLapState.idle);
+    });
+  });
+
   group('AutoLapDetector — reset', () {
     test('reset returns to idle and clears all state', () {
       final detector = AutoLapDetector(_cfg(startConfirm: 1));


### PR DESCRIPTION
Force-end any effort that reaches 90 seconds, since the MAP curve only covers 1–90s and longer efforts provide no additional data. The cap check runs in the inEffort state before natural end-detection.

Added kMaxEffortSeconds constant and cap logic to AutoLapDetector with three test cases covering exact 90s cap, 91s+ behavior, and natural end before cap.