### PR TITLE
Period navigation for span selector

### DIFF
--- a/lib/presentation/providers/historical_range_provider.dart
+++ b/lib/presentation/providers/historical_range_provider.dart
@@ -1,10 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/domain/models/historical_range.dart';
-import 'package:wattalizer/domain/models/history_span.dart';
 import 'package:wattalizer/domain/services/historical_range_calculator.dart';
 import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
 import 'package:wattalizer/presentation/providers/span_selection_provider.dart';
 import 'package:wattalizer/presentation/providers/tag_filter_provider.dart';
+import 'package:wattalizer/presentation/utils/period_utils.dart';
 
 /// Computes best/worst envelopes for the selected span and tag filter.
 /// autoDispose — only alive while a screen needs it.
@@ -12,22 +12,17 @@ import 'package:wattalizer/presentation/providers/tag_filter_provider.dart';
 // (brackets omitted: importing ride_session_provider here would be circular)
 final FutureProvider<HistoricalRange?> historicalRangeProvider =
     FutureProvider.autoDispose<HistoricalRange?>((ref) async {
-  final span = ref.watch(spanSelectionProvider);
+  final selection = ref.watch(spanSelectionProvider);
   final tags = ref.watch(tagFilterProvider);
   final repo = ref.read(rideRepositoryProvider);
   final calc = HistoricalRangeCalculator();
 
-  final now = DateTime.now();
-  final from = switch (span) {
-    HistorySpan.week => now.subtract(const Duration(days: 7)),
-    HistorySpan.month => DateTime(now.year, now.month - 1, now.day),
-    HistorySpan.year => DateTime(now.year - 1, now.month, now.day),
-    HistorySpan.allTime => null,
-  };
+  final period =
+      computePeriod(selection.span, selection.offset, DateTime.now());
 
   final curves = await repo.getAllEffortCurves(
-    from: from,
-    to: now,
+    from: period.from,
+    to: period.to,
     tags: tags.isEmpty ? null : tags,
   );
 

--- a/lib/presentation/providers/ride_list_provider.dart
+++ b/lib/presentation/providers/ride_list_provider.dart
@@ -1,29 +1,24 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/domain/interfaces/ride_repository.dart';
-import 'package:wattalizer/domain/models/history_span.dart';
 import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
 import 'package:wattalizer/presentation/providers/span_selection_provider.dart';
 import 'package:wattalizer/presentation/providers/tag_filter_provider.dart';
+import 'package:wattalizer/presentation/utils/period_utils.dart';
 
 /// Rides filtered by the selected span and tag filter.
 /// autoDispose — only alive while the History screen is open.
 final FutureProvider<List<RideSummaryRow>> rideListProvider =
     FutureProvider.autoDispose<List<RideSummaryRow>>((ref) async {
-  final span = ref.watch(spanSelectionProvider);
+  final selection = ref.watch(spanSelectionProvider);
   final tags = ref.watch(tagFilterProvider);
   final repo = ref.read(rideRepositoryProvider);
 
-  final now = DateTime.now();
-  final from = switch (span) {
-    HistorySpan.week => now.subtract(const Duration(days: 7)),
-    HistorySpan.month => DateTime(now.year, now.month - 1, now.day),
-    HistorySpan.year => DateTime(now.year - 1, now.month, now.day),
-    HistorySpan.allTime => null,
-  };
+  final period =
+      computePeriod(selection.span, selection.offset, DateTime.now());
 
   return repo.getRides(
-    from: from,
-    to: now,
+    from: period.from,
+    to: period.to,
     tags: tags.isEmpty ? null : tags,
   );
 });

--- a/lib/presentation/providers/span_selection_provider.dart
+++ b/lib/presentation/providers/span_selection_provider.dart
@@ -1,18 +1,30 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/domain/models/history_span.dart';
 
-/// Single source of truth for the selected history span.
+typedef PeriodSelection = ({HistorySpan span, int offset});
+
+/// Single source of truth for the selected history span and period offset.
 /// keepAlive — historicalRangeProvider and rideListProvider watch this.
 // (brackets omitted: importing those providers here would be circular)
 final spanSelectionProvider =
-    NotifierProvider<SpanSelectionNotifier, HistorySpan>(
+    NotifierProvider<SpanSelectionNotifier, PeriodSelection>(
   SpanSelectionNotifier.new,
 );
 
-class SpanSelectionNotifier extends Notifier<HistorySpan> {
+class SpanSelectionNotifier extends Notifier<PeriodSelection> {
   @override
-  HistorySpan build() => HistorySpan.allTime;
+  PeriodSelection build() => (span: HistorySpan.allTime, offset: 0);
 
-  HistorySpan get span => state;
-  set span(HistorySpan value) => state = value;
+  /// Switches to [span] and resets offset to current period.
+  void setSpan(HistorySpan span) => state = (span: span, offset: 0);
+
+  /// Steps back one period.
+  void stepBack() => state = (span: state.span, offset: state.offset - 1);
+
+  /// Steps forward one period. No-op when already at current period.
+  void stepForward() {
+    if (state.offset < 0) {
+      state = (span: state.span, offset: state.offset + 1);
+    }
+  }
 }

--- a/lib/presentation/utils/period_utils.dart
+++ b/lib/presentation/utils/period_utils.dart
@@ -1,0 +1,99 @@
+import 'package:wattalizer/domain/models/history_span.dart';
+
+typedef PeriodBounds = ({DateTime? from, DateTime? to, String label});
+
+/// Converts a [HistorySpan] + [offset] into a date range and display label.
+///
+/// [offset] of 0 means "current period" (always ends at [now]).
+/// Negative offsets step backwards: -1 = previous period, -2 = two periods ago.
+/// Forward navigation is clamped at 0 (can't go into the future).
+PeriodBounds computePeriod(
+  HistorySpan span,
+  int offset,
+  DateTime now,
+) {
+  switch (span) {
+    case HistorySpan.allTime:
+      return (from: null, to: null, label: 'All');
+    case HistorySpan.week:
+      final monday = _isoWeekMonday(now);
+      final targetMonday = DateTime(
+        monday.year,
+        monday.month,
+        monday.day + 7 * offset,
+      );
+      final label = _weekLabel(targetMonday);
+      if (offset == 0) {
+        return (from: targetMonday, to: now, label: label);
+      }
+      final endExclusive = DateTime(
+        targetMonday.year,
+        targetMonday.month,
+        targetMonday.day + 7,
+      );
+      return (from: targetMonday, to: endExclusive, label: label);
+    case HistorySpan.month:
+      final targetMonth = DateTime(now.year, now.month + offset);
+      final from = DateTime(targetMonth.year, targetMonth.month);
+      final label = _monthLabel(targetMonth);
+      if (offset == 0) {
+        return (from: from, to: now, label: label);
+      }
+      final endExclusive = DateTime(targetMonth.year, targetMonth.month + 1);
+      return (from: from, to: endExclusive, label: label);
+    case HistorySpan.year:
+      final year = now.year + offset;
+      final from = DateTime(year);
+      if (offset == 0) {
+        return (from: from, to: now, label: '$year');
+      }
+      return (from: from, to: DateTime(year + 1), label: '$year');
+  }
+}
+
+DateTime _isoWeekMonday(DateTime date) {
+  final d = date.subtract(Duration(days: date.weekday - 1));
+  return DateTime(d.year, d.month, d.day);
+}
+
+String _weekLabel(DateTime monday) {
+  final sunday = monday.add(const Duration(days: 6));
+  const m = [
+    '',
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  if (monday.month == sunday.month) {
+    return '${monday.day}–${sunday.day} ${m[monday.month]}';
+  }
+  return '${monday.day} ${m[monday.month]}–${sunday.day} ${m[sunday.month]}';
+}
+
+String _monthLabel(DateTime date) {
+  const months = [
+    '',
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ];
+  return '${months[date.month]} ${date.year}';
+}

--- a/lib/presentation/widgets/span_selector.dart
+++ b/lib/presentation/widgets/span_selector.dart
@@ -2,27 +2,77 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/domain/models/history_span.dart';
 import 'package:wattalizer/presentation/providers/span_selection_provider.dart';
+import 'package:wattalizer/presentation/utils/period_utils.dart';
 
 class SpanSelector extends ConsumerWidget {
   const SpanSelector({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selected = ref.watch(spanSelectionProvider);
+    final selection = ref.watch(spanSelectionProvider);
+    final showNav = selection.span != HistorySpan.allTime;
+    final period =
+        computePeriod(selection.span, selection.offset, DateTime.now());
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-      child: SegmentedButton<HistorySpan>(
-        segments: const [
-          ButtonSegment(value: HistorySpan.week, label: Text('Week')),
-          ButtonSegment(value: HistorySpan.month, label: Text('Month')),
-          ButtonSegment(value: HistorySpan.year, label: Text('Year')),
-          ButtonSegment(value: HistorySpan.allTime, label: Text('All')),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SegmentedButton<HistorySpan>(
+            segments: const [
+              ButtonSegment(value: HistorySpan.week, label: Text('Week')),
+              ButtonSegment(value: HistorySpan.month, label: Text('Month')),
+              ButtonSegment(value: HistorySpan.year, label: Text('Year')),
+              ButtonSegment(value: HistorySpan.allTime, label: Text('All')),
+            ],
+            selected: {selection.span},
+            onSelectionChanged: (s) =>
+                ref.read(spanSelectionProvider.notifier).setSpan(s.first),
+          ),
+          if (showNav)
+            _PeriodNav(
+              label: period.label,
+              offset: selection.offset,
+              onBack: ref.read(spanSelectionProvider.notifier).stepBack,
+              onForward: ref.read(spanSelectionProvider.notifier).stepForward,
+            ),
         ],
-        selected: {selected},
-        onSelectionChanged: (s) =>
-            ref.read(spanSelectionProvider.notifier).span = s.first,
       ),
+    );
+  }
+}
+
+class _PeriodNav extends StatelessWidget {
+  const _PeriodNav({
+    required this.label,
+    required this.offset,
+    required this.onBack,
+    required this.onForward,
+  });
+
+  final String label;
+  final int offset;
+  final VoidCallback onBack;
+  final VoidCallback onForward;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        IconButton(
+          icon: const Icon(Icons.chevron_left),
+          onPressed: onBack,
+          tooltip: 'Previous period',
+        ),
+        Text(label, style: Theme.of(context).textTheme.bodyMedium),
+        IconButton(
+          icon: const Icon(Icons.chevron_right),
+          onPressed: offset < 0 ? onForward : null,
+          tooltip: 'Next period',
+        ),
+      ],
     );
   }
 }

--- a/test/presentation/providers/historical_range_provider_test.dart
+++ b/test/presentation/providers/historical_range_provider_test.dart
@@ -58,7 +58,7 @@ void main() {
       final container = createTestContainer(repository: repo);
       addTearDown(container.dispose);
 
-      container.read(spanSelectionProvider.notifier).span = HistorySpan.week;
+      container.read(spanSelectionProvider.notifier).setSpan(HistorySpan.week);
       container.read(tagFilterProvider.notifier).addTag('track');
       await container.read(historicalRangeProvider.future);
 

--- a/test/presentation/providers/ride_list_provider_test.dart
+++ b/test/presentation/providers/ride_list_provider_test.dart
@@ -48,20 +48,21 @@ void main() {
       expect(repo.getRidesCalls.first.from, isNull);
     });
 
-    test('week span passes a from date 7 days ago', () async {
+    test('week span passes from date at start of current ISO week', () async {
       final repo = FakeRepository();
       final container = createTestContainer(repository: repo);
       addTearDown(container.dispose);
 
-      container.read(spanSelectionProvider.notifier).span = HistorySpan.week;
+      container.read(spanSelectionProvider.notifier).setSpan(HistorySpan.week);
       await container.read(rideListProvider.future);
 
       expect(repo.getRidesCalls, hasLength(1));
       final call = repo.getRidesCalls.first;
       expect(call.from, isNotNull);
-      // from should be approximately 7 days ago
+      // from should be Monday of current ISO week (0–6 days ago)
       final diff = DateTime.now().difference(call.from!);
-      expect(diff.inDays, closeTo(7, 1));
+      expect(diff.inDays, lessThanOrEqualTo(6));
+      expect(diff.inDays, greaterThanOrEqualTo(0));
     });
 
     test('passes tags from tagFilterProvider', () async {

--- a/test/presentation/providers/span_selection_provider_test.dart
+++ b/test/presentation/providers/span_selection_provider_test.dart
@@ -6,31 +6,111 @@ import '../fixtures/test_container.dart';
 
 void main() {
   group('spanSelectionProvider', () {
-    test('default state is HistorySpan.allTime', () {
+    test('default state is allTime with offset 0', () {
       final container = createTestContainer();
       addTearDown(container.dispose);
 
-      expect(container.read(spanSelectionProvider), HistorySpan.allTime);
+      final state = container.read(spanSelectionProvider);
+      expect(state.span, HistorySpan.allTime);
+      expect(state.offset, 0);
     });
 
-    test('setter changes state', () {
+    test('setSpan changes span and resets offset to 0', () {
       final container = createTestContainer();
       addTearDown(container.dispose);
 
-      container.read(spanSelectionProvider.notifier).span = HistorySpan.week;
+      container.read(spanSelectionProvider.notifier).setSpan(HistorySpan.week);
 
-      expect(container.read(spanSelectionProvider), HistorySpan.week);
+      final state = container.read(spanSelectionProvider);
+      expect(state.span, HistorySpan.week);
+      expect(state.offset, 0);
     });
 
-    test('accepts each enum value', () {
+    test('setSpan resets offset when switching spans', () {
+      final container = createTestContainer();
+      addTearDown(container.dispose);
+
+      container.read(spanSelectionProvider.notifier)
+        ..setSpan(HistorySpan.week)
+        ..stepBack()
+        ..stepBack();
+      container.read(spanSelectionProvider.notifier).setSpan(HistorySpan.month);
+
+      final state = container.read(spanSelectionProvider);
+      expect(state.span, HistorySpan.month);
+      expect(state.offset, 0);
+    });
+
+    test('accepts each span value', () {
       for (final span in HistorySpan.values) {
         final container = createTestContainer();
         addTearDown(container.dispose);
 
-        container.read(spanSelectionProvider.notifier).span = span;
+        container.read(spanSelectionProvider.notifier).setSpan(span);
 
-        expect(container.read(spanSelectionProvider), span);
+        expect(container.read(spanSelectionProvider).span, span);
       }
+    });
+
+    test('stepBack decrements offset', () {
+      final container = createTestContainer();
+      addTearDown(container.dispose);
+
+      container.read(spanSelectionProvider.notifier)
+        ..setSpan(HistorySpan.week)
+        ..stepBack();
+
+      expect(container.read(spanSelectionProvider).offset, -1);
+    });
+
+    test('stepBack can go arbitrarily far back', () {
+      final container = createTestContainer();
+      addTearDown(container.dispose);
+
+      final notifier = container.read(spanSelectionProvider.notifier)
+        ..setSpan(HistorySpan.month);
+      for (var i = 0; i < 5; i++) {
+        notifier.stepBack();
+      }
+
+      expect(container.read(spanSelectionProvider).offset, -5);
+    });
+
+    test('stepForward does nothing at offset 0', () {
+      final container = createTestContainer();
+      addTearDown(container.dispose);
+
+      container.read(spanSelectionProvider.notifier)
+        ..setSpan(HistorySpan.week)
+        ..stepForward();
+
+      expect(container.read(spanSelectionProvider).offset, 0);
+    });
+
+    test('stepForward increments offset when negative', () {
+      final container = createTestContainer();
+      addTearDown(container.dispose);
+
+      container.read(spanSelectionProvider.notifier)
+        ..setSpan(HistorySpan.week)
+        ..stepBack()
+        ..stepBack()
+        ..stepForward();
+
+      expect(container.read(spanSelectionProvider).offset, -1);
+    });
+
+    test('stepForward clamps at 0', () {
+      final container = createTestContainer();
+      addTearDown(container.dispose);
+
+      container.read(spanSelectionProvider.notifier)
+        ..setSpan(HistorySpan.week)
+        ..stepBack()
+        ..stepForward()
+        ..stepForward();
+
+      expect(container.read(spanSelectionProvider).offset, 0);
     });
   });
 }

--- a/test/presentation/utils/period_utils_test.dart
+++ b/test/presentation/utils/period_utils_test.dart
@@ -1,0 +1,97 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/models/history_span.dart';
+import 'package:wattalizer/presentation/utils/period_utils.dart';
+
+void main() {
+  // Wednesday, 5 March 2025, 14:00
+  final wednesday = DateTime(2025, 3, 5, 14);
+  // Monday, 3 March 2025
+  final thisMondayMidnight = DateTime(2025, 3, 3);
+
+  group('computePeriod – allTime', () {
+    test('returns null bounds and All label', () {
+      final p = computePeriod(HistorySpan.allTime, 0, wednesday);
+      expect(p.from, isNull);
+      expect(p.to, isNull);
+      expect(p.label, 'All');
+    });
+
+    test('offset ignored for allTime', () {
+      final p = computePeriod(HistorySpan.allTime, -5, wednesday);
+      expect(p.from, isNull);
+      expect(p.to, isNull);
+    });
+  });
+
+  group('computePeriod – week', () {
+    test('offset 0: from is Monday of current week, to is now', () {
+      final p = computePeriod(HistorySpan.week, 0, wednesday);
+      expect(p.from, thisMondayMidnight);
+      expect(p.to, wednesday);
+    });
+
+    test('offset 0: label shows full week range', () {
+      final p = computePeriod(HistorySpan.week, 0, wednesday);
+      expect(p.label, '3–9 Mar');
+    });
+
+    test('offset -1: previous week Mon–Sun', () {
+      final p = computePeriod(HistorySpan.week, -1, wednesday);
+      expect(p.from, DateTime(2025, 2, 24));
+      expect(p.to, DateTime(2025, 3, 3));
+      expect(p.label, '24 Feb–2 Mar');
+    });
+
+    test('offset -2: two weeks ago', () {
+      final p = computePeriod(HistorySpan.week, -2, wednesday);
+      expect(p.from, DateTime(2025, 2, 17));
+      expect(p.to, DateTime(2025, 2, 24));
+      expect(p.label, '17–23 Feb');
+    });
+
+    test('week spanning months uses abbreviated month names for both', () {
+      final p = computePeriod(HistorySpan.week, -1, wednesday);
+      expect(p.label, contains('Feb'));
+      expect(p.label, contains('Mar'));
+    });
+  });
+
+  group('computePeriod – month', () {
+    test('offset 0: from is 1st of month, to is now', () {
+      final p = computePeriod(HistorySpan.month, 0, wednesday);
+      expect(p.from, DateTime(2025, 3));
+      expect(p.to, wednesday);
+      expect(p.label, 'March 2025');
+    });
+
+    test('offset -1: previous full month', () {
+      final p = computePeriod(HistorySpan.month, -1, wednesday);
+      expect(p.from, DateTime(2025, 2));
+      expect(p.to, DateTime(2025, 3));
+      expect(p.label, 'February 2025');
+    });
+
+    test('offset -13: crosses year boundary', () {
+      final p = computePeriod(HistorySpan.month, -13, wednesday);
+      expect(p.from, DateTime(2024, 2));
+      expect(p.to, DateTime(2024, 3));
+      expect(p.label, 'February 2024');
+    });
+  });
+
+  group('computePeriod – year', () {
+    test('offset 0: from Jan 1, to now', () {
+      final p = computePeriod(HistorySpan.year, 0, wednesday);
+      expect(p.from, DateTime(2025));
+      expect(p.to, wednesday);
+      expect(p.label, '2025');
+    });
+
+    test('offset -1: previous full year', () {
+      final p = computePeriod(HistorySpan.year, -1, wednesday);
+      expect(p.from, DateTime(2024));
+      expect(p.to, DateTime(2025));
+      expect(p.label, '2024');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Add prev/next navigation arrows to the span selector (Week/Month/Year), allowing users to step through historical periods without changing the span. The "All" option hides the navigation row. Forward arrow is disabled at the current period (offset 0).

## Changes
- New `PeriodSelection` record `({span, offset})` replaces bare `HistorySpan` state
- `computePeriod()` utility converts span+offset into date range and display label
- `SpanSelector` widget gains `_PeriodNav` row with ← label → controls
- `ride_list` and `historical_range` providers use `computePeriod()` to filter by period
- 12 new `period_utils` tests; provider tests updated to use new API

All 84 presentation tests passing, no analysis warnings.