### PR TITLE
[Feat] PDC provenance tap-to-navigate

### DIFF
--- a/lib/presentation/screens/pdc_screen.dart
+++ b/lib/presentation/screens/pdc_screen.dart
@@ -1,8 +1,11 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/domain/models/historical_range.dart';
 import 'package:wattalizer/domain/models/map_curve.dart';
 import 'package:wattalizer/presentation/providers/historical_range_provider.dart';
+import 'package:wattalizer/presentation/screens/ride_detail_screen.dart';
 import 'package:wattalizer/presentation/widgets/map_curve_chart.dart';
 import 'package:wattalizer/presentation/widgets/span_selector.dart';
 import 'package:wattalizer/presentation/widgets/tag_filter.dart';
@@ -50,6 +53,20 @@ class _PdcContent extends StatelessWidget {
 
   final HistoricalRange range;
 
+  void _navigateToRecord(BuildContext context, DurationRecord record) {
+    unawaited(
+      Navigator.push<void>(
+        context,
+        MaterialPageRoute<void>(
+          builder: (_) => RideDetailScreen(
+            rideId: record.rideId,
+            scrollToEffortId: record.effortId,
+          ),
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final curve = _curveFromBest(range);
@@ -63,10 +80,14 @@ class _PdcContent extends StatelessWidget {
               curve: curve,
               historicalRange: range,
               provenanceRecords: range.best,
+              onProvenanceTap: (r) => _navigateToRecord(context, r),
             ),
           ),
           const SizedBox(height: 12),
-          _StatCards(best: range.best),
+          _StatCards(
+            best: range.best,
+            onTap: (r) => _navigateToRecord(context, r),
+          ),
           const SizedBox(height: 16),
         ],
       ),
@@ -86,9 +107,10 @@ class _PdcContent extends StatelessWidget {
 const _keyDurations = [1, 5, 15, 30, 60, 90];
 
 class _StatCards extends StatelessWidget {
-  const _StatCards({required this.best});
+  const _StatCards({required this.best, this.onTap});
 
   final List<DurationRecord> best;
+  final void Function(DurationRecord record)? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -99,27 +121,34 @@ class _StatCards extends StatelessWidget {
         final record = best[d - 1];
         return SizedBox(
           width: 100,
-          child: Card(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
-              child: Column(
-                children: [
-                  Text(
-                    '${d}s',
-                    style: TextStyle(
-                      fontSize: 12,
-                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+          child: InkWell(
+            onTap: onTap != null ? () => onTap!(record) : null,
+            borderRadius: BorderRadius.circular(12),
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  vertical: 10,
+                  horizontal: 8,
+                ),
+                child: Column(
+                  children: [
+                    Text(
+                      '${d}s',
+                      style: TextStyle(
+                        fontSize: 12,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
                     ),
-                  ),
-                  const SizedBox(height: 2),
-                  Text(
-                    '${record.power.round()} W',
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
+                    const SizedBox(height: 2),
+                    Text(
+                      '${record.power.round()} W',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/presentation/screens/ride_detail_screen.dart
+++ b/lib/presentation/screens/ride_detail_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:share_plus/share_plus.dart';
@@ -17,9 +19,14 @@ import 'package:wattalizer/presentation/widgets/effort_timeline.dart';
 import 'package:wattalizer/presentation/widgets/tag_input.dart';
 
 class RideDetailScreen extends ConsumerWidget {
-  const RideDetailScreen({required this.rideId, super.key});
+  const RideDetailScreen({
+    required this.rideId,
+    this.scrollToEffortId,
+    super.key,
+  });
 
   final String rideId;
+  final String? scrollToEffortId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -41,7 +48,12 @@ class RideDetailScreen extends ConsumerWidget {
           );
         }
         final range = rangeAsync.asData?.value;
-        return _DetailView(ride: ride, historicalRange: range, ref: ref);
+        return _DetailView(
+          ride: ride,
+          historicalRange: range,
+          ref: ref,
+          scrollToEffortId: scrollToEffortId,
+        );
       },
     );
   }
@@ -56,11 +68,13 @@ class _DetailView extends StatefulWidget {
     required this.ride,
     required this.historicalRange,
     required this.ref,
+    this.scrollToEffortId,
   });
 
   final Ride ride;
   final HistoricalRange? historicalRange;
   final WidgetRef ref;
+  final String? scrollToEffortId;
 
   @override
   State<_DetailView> createState() => _DetailViewState();
@@ -68,6 +82,33 @@ class _DetailView extends StatefulWidget {
 
 class _DetailViewState extends State<_DetailView> {
   int? _expandedEffort;
+  final Map<String, GlobalKey> _effortKeys = {};
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.scrollToEffortId != null) {
+      final match = widget.ride.efforts
+          .where((e) => e.id == widget.scrollToEffortId)
+          .firstOrNull;
+      if (match != null) {
+        _expandedEffort = match.effortNumber;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final key = _effortKeys[match.id];
+          if (key?.currentContext != null) {
+            unawaited(
+              Scrollable.ensureVisible(
+                key!.currentContext!,
+                duration: const Duration(milliseconds: 350),
+                curve: Curves.easeInOut,
+                alignment: 0.1,
+              ),
+            );
+          }
+        });
+      }
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -118,8 +159,10 @@ class _DetailViewState extends State<_DetailView> {
               const SizedBox(height: 12),
 
               // Effort cards
-              ...ride.efforts.map(
-                (e) => Padding(
+              ...ride.efforts.map((e) {
+                _effortKeys.putIfAbsent(e.id, GlobalKey.new);
+                return Padding(
+                  key: _effortKeys[e.id],
                   padding: const EdgeInsets.only(bottom: 8),
                   child: EffortCard(
                     effort: e,
@@ -132,8 +175,8 @@ class _DetailViewState extends State<_DetailView> {
                     }),
                     onDelete: () => _deleteEffort(ride, e.effortNumber),
                   ),
-                ),
-              ),
+                );
+              }),
             ],
           ],
         ),

--- a/lib/presentation/widgets/map_curve_chart.dart
+++ b/lib/presentation/widgets/map_curve_chart.dart
@@ -14,6 +14,7 @@ class MapCurveChart extends StatelessWidget {
     this.provenanceRecords,
     this.effortDuration,
     this.compact = false,
+    this.onProvenanceTap,
     super.key,
   });
 
@@ -25,6 +26,9 @@ class MapCurveChart extends StatelessWidget {
   /// the sprint region is shaded; the rest of the 90s curve is unshaded.
   final int? effortDuration;
   final bool compact;
+
+  /// Called when the user taps a data point that has provenance info.
+  final void Function(DurationRecord record)? onProvenanceTap;
 
   @override
   Widget build(BuildContext context) {
@@ -186,6 +190,19 @@ class MapCurveChart extends StatelessWidget {
                       );
                     }).toList(),
                   ),
+                  touchCallback: (event, response) {
+                    if (event is! FlTapUpEvent) return;
+                    if (onProvenanceTap == null || provenanceRecords == null) {
+                      return;
+                    }
+                    final spot = response?.lineBarSpots
+                        ?.where((s) => s.barIndex == 0)
+                        .firstOrNull;
+                    if (spot == null) return;
+                    final idx = spot.x.toInt() - 1;
+                    if (idx < 0 || idx >= provenanceRecords!.length) return;
+                    onProvenanceTap!(provenanceRecords![idx]);
+                  },
                 ),
         ),
       ),
@@ -202,7 +219,8 @@ class MapCurveChart extends StatelessWidget {
     final r = provenanceRecords![idx];
     final d = r.rideDate.toLocal();
     final date = '${d.day}/${d.month}/${d.year}';
-    return '$base\nEffort #${r.effortNumber}, $date';
+    final hint = onProvenanceTap != null ? '\nTap to open' : '';
+    return '$base\nEffort #${r.effortNumber}, $date$hint';
   }
 
   double _maxY(List<FlSpot> spots) {


### PR DESCRIPTION
## Summary
- Tap a chart point or stat card on PDC screen to open matching RideDetailScreen
- Source effort auto-expands and scrolls into view
- Tooltips hint 'Tap to open' when tappable

## Changes
- `MapCurveChart`: onProvenanceTap callback + touchCallback for FlTapUpEvent
- `PdcScreen`: navigation closure wired to chart and stat cards  
- `RideDetailScreen`: scrollToEffortId param, GlobalKey map, post-frame scroll

## Testing
- All 381 tests pass
- Verified edge case: single-effort ride navigates correctly