### PR TITLE
[GUI] Tighten NavigationRail left margin

### DIFF
--- a/lib/presentation/screens/app_shell.dart
+++ b/lib/presentation/screens/app_shell.dart
@@ -101,6 +101,7 @@ class _AppShellState extends ConsumerState<AppShell> {
             body: Row(
               children: [
                 NavigationRail(
+                  minWidth: 64,
                   selectedIndex: _selectedIndex,
                   onDestinationSelected: (i) =>
                       setState(() => _selectedIndex = i),


### PR DESCRIPTION
Reduce NavigationRail minWidth from 80 to 64 to shrink the centering gap between the screen edge and rail icons. Safe area protection for notches is preserved.