### PR TITLE
[GUI] Move import rides to history FAB

### DIFF
--- a/lib/presentation/screens/history_screen.dart
+++ b/lib/presentation/screens/history_screen.dart
@@ -7,6 +7,7 @@ import 'package:wattalizer/presentation/providers/ride_list_provider.dart';
 import 'package:wattalizer/presentation/providers/ride_pdc_provider.dart';
 import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
 import 'package:wattalizer/presentation/screens/ride_detail_screen.dart';
+import 'package:wattalizer/presentation/widgets/import_fab.dart';
 import 'package:wattalizer/presentation/widgets/span_selector.dart';
 import 'package:wattalizer/presentation/widgets/sparkline.dart';
 import 'package:wattalizer/presentation/widgets/tag_filter.dart';
@@ -19,6 +20,7 @@ class HistoryScreen extends ConsumerWidget {
     final ridesAsync = ref.watch(rideListProvider);
 
     return Scaffold(
+      floatingActionButton: const ImportFab(),
       body: SafeArea(
         child: Column(
           children: [

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -1,19 +1,11 @@
 import 'dart:async';
-import 'dart:io';
 
-import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/core/constants.dart';
-import 'package:wattalizer/core/error_types.dart';
-import 'package:wattalizer/domain/models/autolap_config.dart';
-import 'package:wattalizer/domain/services/export_service.dart';
 import 'package:wattalizer/presentation/providers/autolap_config_provider.dart';
-import 'package:wattalizer/presentation/providers/export_service_provider.dart';
-import 'package:wattalizer/presentation/providers/historical_range_provider.dart';
 import 'package:wattalizer/presentation/providers/max_power_override_provider.dart';
 import 'package:wattalizer/presentation/providers/max_power_provider.dart';
-import 'package:wattalizer/presentation/providers/ride_list_provider.dart';
 import 'package:wattalizer/presentation/providers/theme_mode_provider.dart';
 import 'package:wattalizer/presentation/screens/autolap_config_list_screen.dart';
 import 'package:wattalizer/presentation/widgets/device_sheet.dart';
@@ -33,8 +25,6 @@ class SettingsScreen extends ConsumerWidget {
             const _AutoLapSection(),
             const Divider(),
             const _MaxPowerSection(),
-            const Divider(),
-            const _ImportSection(),
             const Divider(),
             const _DevicesSection(),
             const Divider(),
@@ -183,227 +173,6 @@ class _MaxPowerSectionState extends ConsumerState<_MaxPowerSection> {
         ),
         const SizedBox(height: 8),
       ],
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Import
-// ---------------------------------------------------------------------------
-
-class _ImportSection extends ConsumerStatefulWidget {
-  const _ImportSection();
-
-  @override
-  ConsumerState<_ImportSection> createState() => _ImportSectionState();
-}
-
-class _ImportSectionState extends ConsumerState<_ImportSection> {
-  bool _importing = false;
-  ({int done, int total})? _zipProgress;
-
-  Future<void> _import() async {
-    final result = await FilePicker.platform.pickFiles(
-      type: FileType.custom,
-      allowedExtensions: ['tcx', 'fit', 'zip', 'gz'],
-    );
-    if (result == null || result.files.isEmpty) return;
-    final file = result.files.first;
-    if (file.path == null) return;
-
-    setState(() {
-      _importing = true;
-      _zipProgress = null;
-    });
-
-    try {
-      final export = ref.read(exportServiceProvider);
-      final configAsync = ref.read(autoLapConfigProvider);
-      final config = configAsync.value ?? AutoLapConfig.standingStart();
-      final ioFile = File(file.path!);
-      final name = file.name.toLowerCase();
-
-      if (name.endsWith('.zip')) {
-        final results = await export.importZip(
-          ioFile,
-          config,
-          onProgress: (done, total) {
-            if (mounted) {
-              setState(() => _zipProgress = (done: done, total: total));
-            }
-          },
-        );
-        if (mounted) _showDetailedResults(results);
-      } else {
-        try {
-          final ride = name.endsWith('.fit') || name.endsWith('.fit.gz')
-              ? await export.importFit(ioFile, config)
-              : await export.importTcx(ioFile, config);
-
-          if (mounted) {
-            _showDetailedResults(
-              [ImportResult(fileName: file.name, ride: ride)],
-            );
-          }
-        } on ImportError catch (e) {
-          if (mounted) {
-            _showDetailedResults([ImportResult(fileName: file.name, error: e)]);
-          }
-        }
-      }
-      ref
-        ..invalidate(rideListProvider)
-        ..invalidate(historicalRangeProvider)
-        ..invalidate(maxPowerProvider);
-    } on Exception catch (e) {
-      if (mounted) {
-        _showDetailedResults([
-          ImportResult(
-            fileName: file.path!.split(Platform.pathSeparator).last,
-            error: ImportError(
-              fileName: file.path!.split(Platform.pathSeparator).last,
-              type: ImportErrorType.malformedFile,
-              detail: e.toString(),
-            ),
-          ),
-        ]);
-      }
-    } finally {
-      if (mounted) {
-        setState(() {
-          _importing = false;
-          _zipProgress = null;
-        });
-      }
-    }
-  }
-
-  String _errorLabel(ImportErrorType type) => switch (type) {
-        ImportErrorType.malformedFile => 'Invalid file format',
-        ImportErrorType.noTrackpoints => 'No trackpoints',
-        ImportErrorType.noPowerData => 'No power data',
-        ImportErrorType.duplicateRide => 'Duplicate (already imported)',
-        ImportErrorType.fileTooLarge => 'File too large (>50 MB)',
-      };
-
-  void _showDetailedResults(List<ImportResult> results) {
-    final imported = results.where((r) => r.ride != null).length;
-    final errors = results.where((r) => r.error != null).length;
-
-    unawaited(
-      showDialog<void>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: const Text('Import Results'),
-          content: SizedBox(
-            width: double.maxFinite,
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (results.length > 1)
-                    ConstrainedBox(
-                      constraints: const BoxConstraints(maxHeight: 300),
-                      child: ListView.builder(
-                        shrinkWrap: true,
-                        itemCount: results.length,
-                        itemBuilder: (_, i) {
-                          final r = results[i];
-                          final success = r.ride != null;
-                          return ListTile(
-                            dense: true,
-                            contentPadding: EdgeInsets.zero,
-                            leading: Icon(
-                              success
-                                  ? Icons.check_circle
-                                  : Icons.error_outline,
-                              color: success ? Colors.green : Colors.red,
-                              size: 20,
-                            ),
-                            title: Text(
-                              r.fileName,
-                              style: const TextStyle(fontSize: 13),
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            trailing: success
-                                ? null
-                                : Text(
-                                    _errorLabel(r.error!.type),
-                                    style: TextStyle(
-                                      fontSize: 11,
-                                      color: Colors.red.shade300,
-                                    ),
-                                  ),
-                          );
-                        },
-                      ),
-                    )
-                  else if (results.length == 1) ...[
-                    const SizedBox(height: 4),
-                    Row(
-                      children: [
-                        Icon(
-                          results.first.ride != null
-                              ? Icons.check_circle
-                              : Icons.error_outline,
-                          color: results.first.ride != null
-                              ? Colors.green
-                              : Colors.red,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            results.first.error != null
-                                ? _errorLabel(results.first.error!.type)
-                                : 'Imported successfully',
-                            style: const TextStyle(fontSize: 13),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                  const SizedBox(height: 12),
-                  Text(
-                    '$imported imported, '
-                    '$errors error${errors == 1 ? '' : 's'}',
-                    style: Theme.of(ctx).textTheme.bodySmall,
-                  ),
-                ],
-              ),
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final progress = _zipProgress;
-    final subtitle = progress != null
-        ? 'Importing... ${progress.done}/${progress.total}'
-        : 'TCX, FIT, ZIP, or gzipped files';
-
-    return ListTile(
-      leading: const Icon(Icons.file_upload),
-      title: const Text('Import Rides'),
-      subtitle: Text(subtitle),
-      trailing: _importing
-          ? const SizedBox(
-              width: 20,
-              height: 20,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          : const Icon(Icons.chevron_right),
-      onTap: _importing ? null : _import,
     );
   }
 }

--- a/lib/presentation/widgets/import_fab.dart
+++ b/lib/presentation/widgets/import_fab.dart
@@ -1,0 +1,210 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/core/error_types.dart';
+import 'package:wattalizer/domain/models/autolap_config.dart';
+import 'package:wattalizer/domain/services/export_service.dart';
+import 'package:wattalizer/presentation/providers/autolap_config_provider.dart';
+import 'package:wattalizer/presentation/providers/export_service_provider.dart';
+import 'package:wattalizer/presentation/providers/historical_range_provider.dart';
+import 'package:wattalizer/presentation/providers/max_power_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_list_provider.dart';
+
+class ImportFab extends ConsumerStatefulWidget {
+  const ImportFab({super.key});
+
+  @override
+  ConsumerState<ImportFab> createState() => _ImportFabState();
+}
+
+class _ImportFabState extends ConsumerState<ImportFab> {
+  bool _importing = false;
+
+  Future<void> _import() async {
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['tcx', 'fit', 'zip', 'gz'],
+    );
+    if (result == null || result.files.isEmpty) return;
+    final file = result.files.first;
+    if (file.path == null) return;
+
+    setState(() => _importing = true);
+
+    try {
+      final export = ref.read(exportServiceProvider);
+      final configAsync = ref.read(autoLapConfigProvider);
+      final config = configAsync.value ?? AutoLapConfig.standingStart();
+      final ioFile = File(file.path!);
+      final name = file.name.toLowerCase();
+
+      if (name.endsWith('.zip')) {
+        final results = await export.importZip(
+          ioFile,
+          config,
+        );
+        if (mounted) _showDetailedResults(results);
+      } else {
+        try {
+          final ride = name.endsWith('.fit') || name.endsWith('.fit.gz')
+              ? await export.importFit(ioFile, config)
+              : await export.importTcx(ioFile, config);
+
+          if (mounted) {
+            _showDetailedResults(
+              [ImportResult(fileName: file.name, ride: ride)],
+            );
+          }
+        } on ImportError catch (e) {
+          if (mounted) {
+            _showDetailedResults([ImportResult(fileName: file.name, error: e)]);
+          }
+        }
+      }
+      ref
+        ..invalidate(rideListProvider)
+        ..invalidate(historicalRangeProvider)
+        ..invalidate(maxPowerProvider);
+    } on Exception catch (e) {
+      if (mounted) {
+        _showDetailedResults([
+          ImportResult(
+            fileName: file.path!.split(Platform.pathSeparator).last,
+            error: ImportError(
+              fileName: file.path!.split(Platform.pathSeparator).last,
+              type: ImportErrorType.malformedFile,
+              detail: e.toString(),
+            ),
+          ),
+        ]);
+      }
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
+  }
+
+  String _errorLabel(ImportErrorType type) => switch (type) {
+        ImportErrorType.malformedFile => 'Invalid file format',
+        ImportErrorType.noTrackpoints => 'No trackpoints',
+        ImportErrorType.noPowerData => 'No power data',
+        ImportErrorType.duplicateRide => 'Duplicate (already imported)',
+        ImportErrorType.fileTooLarge => 'File too large (>50 MB)',
+      };
+
+  void _showDetailedResults(List<ImportResult> results) {
+    final imported = results.where((r) => r.ride != null).length;
+    final errors = results.where((r) => r.error != null).length;
+
+    unawaited(
+      showDialog<void>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Text('Import Results'),
+          content: SizedBox(
+            width: double.maxFinite,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (results.length > 1)
+                    ConstrainedBox(
+                      constraints: const BoxConstraints(maxHeight: 300),
+                      child: ListView.builder(
+                        shrinkWrap: true,
+                        itemCount: results.length,
+                        itemBuilder: (_, i) {
+                          final r = results[i];
+                          final success = r.ride != null;
+                          return ListTile(
+                            dense: true,
+                            contentPadding: EdgeInsets.zero,
+                            leading: Icon(
+                              success
+                                  ? Icons.check_circle
+                                  : Icons.error_outline,
+                              color: success ? Colors.green : Colors.red,
+                              size: 20,
+                            ),
+                            title: Text(
+                              r.fileName,
+                              style: const TextStyle(fontSize: 13),
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            trailing: success
+                                ? null
+                                : Text(
+                                    _errorLabel(r.error!.type),
+                                    style: TextStyle(
+                                      fontSize: 11,
+                                      color: Colors.red.shade300,
+                                    ),
+                                  ),
+                          );
+                        },
+                      ),
+                    )
+                  else if (results.length == 1) ...[
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Icon(
+                          results.first.ride != null
+                              ? Icons.check_circle
+                              : Icons.error_outline,
+                          color: results.first.ride != null
+                              ? Colors.green
+                              : Colors.red,
+                          size: 20,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            results.first.error != null
+                                ? _errorLabel(results.first.error!.type)
+                                : 'Imported successfully',
+                            style: const TextStyle(fontSize: 13),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                  const SizedBox(height: 12),
+                  Text(
+                    '$imported imported, '
+                    '$errors error${errors == 1 ? '' : 's'}',
+                    style: Theme.of(ctx).textTheme.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('OK'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FloatingActionButton(
+      tooltip: 'Import rides',
+      onPressed: _importing ? null : _import,
+      child: _importing
+          ? const SizedBox(
+              width: 20,
+              height: 20,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : const Icon(Icons.upload_file_outlined),
+    );
+  }
+}


### PR DESCRIPTION
Move import functionality from settings list tile to history screen FAB. Creates ImportFab widget containing all import logic previously in _ImportSection. Updates settings screen to remove unused imports (dart:io, file_picker, error_types, export_service, ride_list_provider).

All 399 tests pass.