### PR TITLE
[Fix] Strip left SafeArea inset from rail content

### DIFF
--- a/lib/presentation/screens/app_shell.dart
+++ b/lib/presentation/screens/app_shell.dart
@@ -110,9 +110,13 @@ class _AppShellState extends ConsumerState<AppShell> {
                 ),
                 const VerticalDivider(thickness: 1, width: 1),
                 Expanded(
-                  child: IndexedStack(
-                    index: _selectedIndex,
-                    children: _screens,
+                  child: MediaQuery.removePadding(
+                    context: context,
+                    removeLeft: true,
+                    child: IndexedStack(
+                      index: _selectedIndex,
+                      children: _screens,
+                    ),
                   ),
                 ),
               ],


### PR DESCRIPTION
On iPhone landscape the notch/Dynamic Island inset flows into content screens via SafeArea, creating a gap between the rail and content. 

Wraps the content area with MediaQuery.removePadding(removeLeft: true) so the rail's left-edge protection prevents double-counting of the system inset.