### PR TITLE
[Build] GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,129 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run code generation
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build macOS
+        run: flutter build macos --release
+
+      - name: Ad-hoc sign
+        run: |
+          codesign --deep --force --sign - \
+            build/macos/Build/Products/Release/wattalizer.app
+
+      - name: Package DMG
+        run: |
+          hdiutil create -volname Wattalizer \
+            -srcfolder build/macos/Build/Products/Release/wattalizer.app \
+            -ov -format UDZO Wattalizer-macos.dmg
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Wattalizer-macos
+          path: Wattalizer-macos.dmg
+
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run code generation
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build Windows
+        run: flutter build windows --release
+
+      - name: Package ZIP
+        run: |
+          Compress-Archive -Path build\windows\x64\runner\Release\* `
+            -DestinationPath Wattalizer-windows.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Wattalizer-windows
+          path: Wattalizer-windows.zip
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang cmake ninja-build libgtk-3-dev
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run code generation
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build Linux
+        run: flutter build linux --release
+
+      - name: Package tarball
+        run: |
+          tar -czf Wattalizer-linux.tar.gz \
+            -C build/linux/x64/release/bundle .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Wattalizer-linux
+          path: Wattalizer-linux.tar.gz
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build-macos, build-windows, build-linux]
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Wattalizer-macos
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Wattalizer-windows
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Wattalizer-linux
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            Wattalizer-macos.dmg
+            Wattalizer-windows.zip
+            Wattalizer-linux.tar.gz


### PR DESCRIPTION
Adds release workflow for building and distributing binaries across macOS, Windows, and Linux.

Triggered on version tags (v*.*.*) or manual dispatch. Builds in parallel: macOS (ad-hoc signed DMG), Windows (ZIP), Linux (tarball). Release job creates GitHub Release with all 3 artifacts on tag pushes.