### PR TITLE
[Build] Release workflow with versioned artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,33 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build (e.g. v0.1.0)'
+        required: true
+
+env:
+  VERSION: ${{ inputs.version || github.ref_name }}
 
 jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify tag matches pubspec version
+        run: |
+          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | awk '{print $2}')
+          TAG_VERSION=${{ env.VERSION }}
+          TAG_VERSION=${TAG_VERSION#v}
+          if [ "$PUBSPEC_VERSION" != "$TAG_VERSION" ]; then
+            echo "${{ env.VERSION }} does not match pubspec version $PUBSPEC_VERSION"
+            exit 1
+          fi
+
   build-macos:
     runs-on: macos-latest
+    needs: [check-version]
+    if: needs.check-version.result == 'success'
     steps:
       - uses: actions/checkout@v4
 
@@ -34,15 +57,17 @@ jobs:
         run: |
           hdiutil create -volname Wattalizer \
             -srcfolder build/macos/Build/Products/Release/wattalizer.app \
-            -ov -format UDZO Wattalizer-macos.dmg
+            -ov -format UDZO Wattalizer-${{ env.VERSION }}-macos.dmg
 
       - uses: actions/upload-artifact@v4
         with:
           name: Wattalizer-macos
-          path: Wattalizer-macos.dmg
+          path: Wattalizer-${{ env.VERSION }}-macos.dmg
 
   build-windows:
     runs-on: windows-latest
+    needs: [check-version]
+    if: needs.check-version.result == 'success'
     steps:
       - uses: actions/checkout@v4
 
@@ -62,15 +87,17 @@ jobs:
       - name: Package ZIP
         run: |
           Compress-Archive -Path build\windows\x64\runner\Release\* `
-            -DestinationPath Wattalizer-windows.zip
+            -DestinationPath Wattalizer-${{ env.VERSION }}-windows.zip
 
       - uses: actions/upload-artifact@v4
         with:
           name: Wattalizer-windows
-          path: Wattalizer-windows.zip
+          path: Wattalizer-${{ env.VERSION }}-windows.zip
 
   build-linux:
     runs-on: ubuntu-latest
+    needs: [check-version]
+    if: needs.check-version.result == 'success'
     steps:
       - uses: actions/checkout@v4
 
@@ -94,17 +121,17 @@ jobs:
 
       - name: Package tarball
         run: |
-          tar -czf Wattalizer-linux.tar.gz \
+          tar -czf Wattalizer-${{ env.VERSION }}-linux.tar.gz \
             -C build/linux/x64/release/bundle .
 
       - uses: actions/upload-artifact@v4
         with:
           name: Wattalizer-linux
-          path: Wattalizer-linux.tar.gz
+          path: Wattalizer-${{ env.VERSION }}-linux.tar.gz
 
   release:
     runs-on: ubuntu-latest
-    needs: [build-macos, build-windows, build-linux]
+    needs: [check-version, build-macos, build-windows, build-linux]
     if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
@@ -124,6 +151,6 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           files: |
-            Wattalizer-macos.dmg
-            Wattalizer-windows.zip
-            Wattalizer-linux.tar.gz
+            Wattalizer-${{ env.VERSION }}-macos.dmg
+            Wattalizer-${{ env.VERSION }}-windows.zip
+            Wattalizer-${{ env.VERSION }}-linux.tar.gz

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: wattalizer
 description: Sprint power analysis for track cyclists
-version: 1.0.0
+version: 0.1.0
 
 environment:
   sdk: ">=3.2.0 <4.0.0"


### PR DESCRIPTION
## Summary
Add GitHub Actions release workflow for macOS, Windows, and Linux with ad-hoc code signing on macOS.

- Versioned artifact filenames (e.g., `Wattalizer-v0.1.0-macos.dmg`)
- `check-version` job validates git tag matches `pubspec.yaml` version
- `workflow_dispatch` requires version input for manual builds
- Set initial version to 0.1.0

All three platforms build and package in parallel, then create a GitHub Release with the signed/packaged artifacts.