### PR TITLE
Add caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,24 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
+          cache: true
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
 
       - name: Install dependencies
         run: flutter pub get
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            .dart_tool/build/
+            lib/data/database/database.g.dart
+          key: codegen-${{ runner.os }}-${{ hashFiles('pubspec.lock', 'lib/data/database/tables.dart', 'lib/data/database/database.dart') }}
+          restore-keys: codegen-${{ runner.os }}-
 
       - name: Run code generation
         run: dart run build_runner build --delete-conflicting-outputs


### PR DESCRIPTION
Cache Flutter SDK, pub packages, and build_runner outputs to speed up CI runs.

- Flutter SDK cache via subosito action
- Pub cache keyed on pubspec.lock
- Build runner output cache keyed on pubspec.lock and tables.dart

Saves 2-3 min on repeated runs with unchanged dependencies.