### PR TITLE
[GUI] OS-level file intents for .fit/.tcx/.gz

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -37,6 +37,41 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <!-- .tcx -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="application/vnd.garmin.tcx+xml"/>
+            </intent-filter>
+            <!-- .fit (binary, match by extension) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="application/octet-stream"
+                      android:pathPattern=".*\\.fit"/>
+            </intent-filter>
+            <!-- .gz (covers .tcx.gz and .fit.gz) -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="application/gzip"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="application/x-gzip"/>
+            </intent-filter>
+            <!-- Wildcard fallbacks for file managers that send */* -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="*/*" android:pathPattern=".*\\.tcx"/>
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="*/*" android:pathPattern=".*\\.fit"/>
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/android/app/src/main/kotlin/com/svenaron/wattalizer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/svenaron/wattalizer/MainActivity.kt
@@ -1,5 +1,77 @@
 package com.svenaron.wattalizer
 
+import android.content.Intent
+import android.net.Uri
+import android.provider.OpenableColumns
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
+import java.io.File
+import java.io.FileOutputStream
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    private val channelName = "wattalizer/file_intents"
+    private var channel: MethodChannel? = null
+    private var pendingFilePath: String? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        channel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            channelName,
+        )
+        channel!!.setMethodCallHandler { call, result ->
+            if (call.method == "getPendingFile") {
+                result.success(pendingFilePath)
+                pendingFilePath = null
+            } else {
+                result.notImplemented()
+            }
+        }
+        handleIntent(intent)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val uri = intent.data ?: return
+        if (intent.action != Intent.ACTION_VIEW) return
+        val path = resolveFilePath(uri) ?: return
+        channel?.invokeMethod("openFile", path)
+    }
+
+    private fun handleIntent(intent: Intent?) {
+        val uri = intent?.data ?: return
+        if (intent.action != Intent.ACTION_VIEW) return
+        pendingFilePath = resolveFilePath(uri)
+    }
+
+    private fun resolveFilePath(uri: Uri): String? = when (uri.scheme) {
+        "file" -> uri.path
+        "content" -> copyContentUri(uri)
+        else -> null
+    }
+
+    private fun copyContentUri(uri: Uri): String? {
+        val fileName = queryDisplayName(uri) ?: uri.lastPathSegment ?: return null
+        val dest = File(cacheDir, fileName)
+        return try {
+            contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(dest).use { output ->
+                    input.copyTo(output)
+                }
+            }
+            dest.absolutePath
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun queryDisplayName(uri: Uri): String? = try {
+        contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+            val col = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (cursor.moveToFirst() && col >= 0) cursor.getString(col) else null
+        }
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -70,5 +70,52 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key><string>com.wattalizer.tcx</string>
+			<key>UTTypeDescription</key><string>Training Center XML</string>
+			<key>UTTypeConformsTo</key><array><string>public.xml</string></array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key><array><string>tcx</string></array>
+				<key>public.mime-type</key>
+				<string>application/vnd.garmin.tcx+xml</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key><string>com.wattalizer.fit</string>
+			<key>UTTypeDescription</key><string>FIT Activity File</string>
+			<key>UTTypeConformsTo</key><array><string>public.data</string></array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key><array><string>fit</string></array>
+			</dict>
+		</dict>
+	</array>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeName</key><string>Training Center XML</string>
+			<key>CFBundleTypeRole</key><string>Viewer</string>
+			<key>LSHandlerRank</key><string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array><string>com.wattalizer.tcx</string></array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key><string>FIT Activity File</string>
+			<key>CFBundleTypeRole</key><string>Viewer</string>
+			<key>LSHandlerRank</key><string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array><string>com.wattalizer.fit</string></array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key><string>Gzip Compressed File</string>
+			<key>CFBundleTypeRole</key><string>Viewer</string>
+			<key>LSHandlerRank</key><string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array><string>org.gnu.gnu-zip-archive</string></array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/ios/Runner/SceneDelegate.swift
+++ b/ios/Runner/SceneDelegate.swift
@@ -2,5 +2,69 @@ import Flutter
 import UIKit
 
 class SceneDelegate: FlutterSceneDelegate {
+  private static let channelName = "wattalizer/file_intents"
+  private var channel: FlutterMethodChannel?
+  private var pendingFilePath: String?
 
+  override func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    super.scene(scene, willConnectTo: session, options: connectionOptions)
+
+    guard
+      let windowScene = scene as? UIWindowScene,
+      let flutterVC = windowScene.windows.first?.rootViewController
+        as? FlutterViewController
+    else { return }
+
+    let ch = FlutterMethodChannel(
+      name: SceneDelegate.channelName,
+      binaryMessenger: flutterVC.binaryMessenger
+    )
+    self.channel = ch
+
+    ch.setMethodCallHandler { [weak self] call, result in
+      if call.method == "getPendingFile" {
+        result(self?.pendingFilePath)
+        self?.pendingFilePath = nil
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
+    if let url = connectionOptions.urlContexts.first?.url {
+      pendingFilePath = resolveFilePath(url)
+    }
+  }
+
+  override func scene(
+    _ scene: UIScene,
+    openURLContexts urlContexts: Set<UIOpenURLContext>
+  ) {
+    guard
+      let url = urlContexts.first?.url,
+      let path = resolveFilePath(url)
+    else { return }
+    channel?.invokeMethod("openFile", arguments: path)
+  }
+
+  private func resolveFilePath(_ url: URL) -> String? {
+    let accessing = url.startAccessingSecurityScopedResource()
+    defer {
+      if accessing { url.stopAccessingSecurityScopedResource() }
+    }
+    let dest = FileManager.default.temporaryDirectory
+      .appendingPathComponent(url.lastPathComponent)
+    do {
+      if FileManager.default.fileExists(atPath: dest.path) {
+        try FileManager.default.removeItem(at: dest)
+      }
+      try FileManager.default.copyItem(at: url, to: dest)
+      return dest.path
+    } catch {
+      return nil
+    }
+  }
 }

--- a/lib/presentation/screens/app_shell.dart
+++ b/lib/presentation/screens/app_shell.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/presentation/layout/breakpoints.dart';
 import 'package:wattalizer/presentation/providers/ride_session_provider.dart';
@@ -6,6 +9,7 @@ import 'package:wattalizer/presentation/screens/history_screen.dart';
 import 'package:wattalizer/presentation/screens/pdc_screen.dart';
 import 'package:wattalizer/presentation/screens/ride_screen.dart';
 import 'package:wattalizer/presentation/screens/settings_screen.dart';
+import 'package:wattalizer/presentation/utils/import_utils.dart';
 
 class AppShell extends ConsumerStatefulWidget {
   const AppShell({super.key});
@@ -15,7 +19,43 @@ class AppShell extends ConsumerStatefulWidget {
 }
 
 class _AppShellState extends ConsumerState<AppShell> {
+  static const _ch = MethodChannel('wattalizer/file_intents');
+
   int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _ch.setMethodCallHandler(_onFileIntent);
+    unawaited(_checkPendingFile());
+  }
+
+  @override
+  void dispose() {
+    _ch.setMethodCallHandler(null);
+    super.dispose();
+  }
+
+  Future<void> _checkPendingFile() async {
+    try {
+      final path = await _ch.invokeMethod<String>('getPendingFile');
+      if (path != null && mounted) await _handleFile(path);
+    } on PlatformException {
+      // Not implemented on this platform — ignore.
+    }
+  }
+
+  Future<void> _onFileIntent(MethodCall call) async {
+    if (call.method == 'openFile' && mounted) {
+      await _handleFile(call.arguments as String);
+    }
+  }
+
+  Future<void> _handleFile(String path) async {
+    setState(() => _selectedIndex = 1); // navigate to History
+    final results = await importFileFromPath(ref, path);
+    if (mounted) showImportResultsDialog(context, results);
+  }
 
   static const _screens = <Widget>[
     RideScreen(),

--- a/lib/presentation/utils/import_utils.dart
+++ b/lib/presentation/utils/import_utils.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/core/error_types.dart';
+import 'package:wattalizer/domain/models/autolap_config.dart';
+import 'package:wattalizer/domain/services/export_service.dart';
+import 'package:wattalizer/presentation/providers/autolap_config_provider.dart';
+import 'package:wattalizer/presentation/providers/export_service_provider.dart';
+import 'package:wattalizer/presentation/providers/historical_range_provider.dart';
+import 'package:wattalizer/presentation/providers/max_power_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_list_provider.dart';
+
+/// Routes [filePath] to importFit, importTcx, or importZip based on
+/// extension. Invalidates list/range/power providers on success.
+/// Never throws — errors are captured as [ImportResult] entries.
+Future<List<ImportResult>> importFileFromPath(
+  WidgetRef ref,
+  String filePath, {
+  String? displayName,
+}) async {
+  final fileName = displayName ?? filePath.split(Platform.pathSeparator).last;
+  final name = fileName.toLowerCase();
+  final file = File(filePath);
+
+  try {
+    final export = ref.read(exportServiceProvider);
+    final configAsync = ref.read(autoLapConfigProvider);
+    final config = configAsync.value ?? AutoLapConfig.standingStart();
+
+    List<ImportResult> results;
+    if (name.endsWith('.zip')) {
+      results = await export.importZip(file, config);
+    } else {
+      try {
+        final ride = name.endsWith('.fit') || name.endsWith('.fit.gz')
+            ? await export.importFit(file, config)
+            : await export.importTcx(file, config);
+        results = [ImportResult(fileName: fileName, ride: ride)];
+      } on ImportError catch (e) {
+        results = [ImportResult(fileName: fileName, error: e)];
+      }
+    }
+
+    ref
+      ..invalidate(rideListProvider)
+      ..invalidate(historicalRangeProvider)
+      ..invalidate(maxPowerProvider);
+
+    return results;
+  } on Exception catch (e) {
+    return [
+      ImportResult(
+        fileName: fileName,
+        error: ImportError(
+          fileName: fileName,
+          type: ImportErrorType.malformedFile,
+          detail: e.toString(),
+        ),
+      ),
+    ];
+  }
+}
+
+String errorLabel(ImportErrorType type) => switch (type) {
+      ImportErrorType.malformedFile => 'Invalid file format',
+      ImportErrorType.noTrackpoints => 'No trackpoints',
+      ImportErrorType.noPowerData => 'No power data',
+      ImportErrorType.duplicateRide => 'Duplicate (already imported)',
+      ImportErrorType.fileTooLarge => 'File too large (>50 MB)',
+    };
+
+void showImportResultsDialog(
+  BuildContext context,
+  List<ImportResult> results,
+) {
+  final imported = results.where((r) => r.ride != null).length;
+  final errors = results.where((r) => r.error != null).length;
+
+  unawaited(
+    showDialog<void>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Import Results'),
+        content: SizedBox(
+          width: double.maxFinite,
+          child: SingleChildScrollView(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (results.length > 1)
+                  ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 300),
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: results.length,
+                      itemBuilder: (_, i) {
+                        final r = results[i];
+                        final success = r.ride != null;
+                        return ListTile(
+                          dense: true,
+                          contentPadding: EdgeInsets.zero,
+                          leading: Icon(
+                            success ? Icons.check_circle : Icons.error_outline,
+                            color: success ? Colors.green : Colors.red,
+                            size: 20,
+                          ),
+                          title: Text(
+                            r.fileName,
+                            style: const TextStyle(fontSize: 13),
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          trailing: success
+                              ? null
+                              : Text(
+                                  errorLabel(r.error!.type),
+                                  style: TextStyle(
+                                    fontSize: 11,
+                                    color: Colors.red.shade300,
+                                  ),
+                                ),
+                        );
+                      },
+                    ),
+                  )
+                else if (results.length == 1) ...[
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(
+                        results.first.ride != null
+                            ? Icons.check_circle
+                            : Icons.error_outline,
+                        color: results.first.ride != null
+                            ? Colors.green
+                            : Colors.red,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          results.first.error != null
+                              ? errorLabel(results.first.error!.type)
+                              : 'Imported successfully',
+                          style: const TextStyle(fontSize: 13),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+                const SizedBox(height: 12),
+                Text(
+                  '$imported imported, '
+                  '$errors error${errors == 1 ? '' : 's'}',
+                  style: Theme.of(ctx).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    ),
+  );
+}

--- a/lib/presentation/widgets/import_fab.dart
+++ b/lib/presentation/widgets/import_fab.dart
@@ -1,17 +1,9 @@
 import 'dart:async';
-import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:wattalizer/core/error_types.dart';
-import 'package:wattalizer/domain/models/autolap_config.dart';
-import 'package:wattalizer/domain/services/export_service.dart';
-import 'package:wattalizer/presentation/providers/autolap_config_provider.dart';
-import 'package:wattalizer/presentation/providers/export_service_provider.dart';
-import 'package:wattalizer/presentation/providers/historical_range_provider.dart';
-import 'package:wattalizer/presentation/providers/max_power_provider.dart';
-import 'package:wattalizer/presentation/providers/ride_list_provider.dart';
+import 'package:wattalizer/presentation/utils/import_utils.dart';
 
 class ImportFab extends ConsumerStatefulWidget {
   const ImportFab({super.key});
@@ -33,164 +25,16 @@ class _ImportFabState extends ConsumerState<ImportFab> {
     if (file.path == null) return;
 
     setState(() => _importing = true);
-
     try {
-      final export = ref.read(exportServiceProvider);
-      final configAsync = ref.read(autoLapConfigProvider);
-      final config = configAsync.value ?? AutoLapConfig.standingStart();
-      final ioFile = File(file.path!);
-      final name = file.name.toLowerCase();
-
-      if (name.endsWith('.zip')) {
-        final results = await export.importZip(
-          ioFile,
-          config,
-        );
-        if (mounted) _showDetailedResults(results);
-      } else {
-        try {
-          final ride = name.endsWith('.fit') || name.endsWith('.fit.gz')
-              ? await export.importFit(ioFile, config)
-              : await export.importTcx(ioFile, config);
-
-          if (mounted) {
-            _showDetailedResults(
-              [ImportResult(fileName: file.name, ride: ride)],
-            );
-          }
-        } on ImportError catch (e) {
-          if (mounted) {
-            _showDetailedResults([ImportResult(fileName: file.name, error: e)]);
-          }
-        }
-      }
-      ref
-        ..invalidate(rideListProvider)
-        ..invalidate(historicalRangeProvider)
-        ..invalidate(maxPowerProvider);
-    } on Exception catch (e) {
-      if (mounted) {
-        _showDetailedResults([
-          ImportResult(
-            fileName: file.path!.split(Platform.pathSeparator).last,
-            error: ImportError(
-              fileName: file.path!.split(Platform.pathSeparator).last,
-              type: ImportErrorType.malformedFile,
-              detail: e.toString(),
-            ),
-          ),
-        ]);
-      }
+      final results = await importFileFromPath(
+        ref,
+        file.path!,
+        displayName: file.name,
+      );
+      if (mounted) showImportResultsDialog(context, results);
     } finally {
       if (mounted) setState(() => _importing = false);
     }
-  }
-
-  String _errorLabel(ImportErrorType type) => switch (type) {
-        ImportErrorType.malformedFile => 'Invalid file format',
-        ImportErrorType.noTrackpoints => 'No trackpoints',
-        ImportErrorType.noPowerData => 'No power data',
-        ImportErrorType.duplicateRide => 'Duplicate (already imported)',
-        ImportErrorType.fileTooLarge => 'File too large (>50 MB)',
-      };
-
-  void _showDetailedResults(List<ImportResult> results) {
-    final imported = results.where((r) => r.ride != null).length;
-    final errors = results.where((r) => r.error != null).length;
-
-    unawaited(
-      showDialog<void>(
-        context: context,
-        builder: (ctx) => AlertDialog(
-          title: const Text('Import Results'),
-          content: SizedBox(
-            width: double.maxFinite,
-            child: SingleChildScrollView(
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  if (results.length > 1)
-                    ConstrainedBox(
-                      constraints: const BoxConstraints(maxHeight: 300),
-                      child: ListView.builder(
-                        shrinkWrap: true,
-                        itemCount: results.length,
-                        itemBuilder: (_, i) {
-                          final r = results[i];
-                          final success = r.ride != null;
-                          return ListTile(
-                            dense: true,
-                            contentPadding: EdgeInsets.zero,
-                            leading: Icon(
-                              success
-                                  ? Icons.check_circle
-                                  : Icons.error_outline,
-                              color: success ? Colors.green : Colors.red,
-                              size: 20,
-                            ),
-                            title: Text(
-                              r.fileName,
-                              style: const TextStyle(fontSize: 13),
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            trailing: success
-                                ? null
-                                : Text(
-                                    _errorLabel(r.error!.type),
-                                    style: TextStyle(
-                                      fontSize: 11,
-                                      color: Colors.red.shade300,
-                                    ),
-                                  ),
-                          );
-                        },
-                      ),
-                    )
-                  else if (results.length == 1) ...[
-                    const SizedBox(height: 4),
-                    Row(
-                      children: [
-                        Icon(
-                          results.first.ride != null
-                              ? Icons.check_circle
-                              : Icons.error_outline,
-                          color: results.first.ride != null
-                              ? Colors.green
-                              : Colors.red,
-                          size: 20,
-                        ),
-                        const SizedBox(width: 8),
-                        Expanded(
-                          child: Text(
-                            results.first.error != null
-                                ? _errorLabel(results.first.error!.type)
-                                : 'Imported successfully',
-                            style: const TextStyle(fontSize: 13),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                  const SizedBox(height: 12),
-                  Text(
-                    '$imported imported, '
-                    '$errors error${errors == 1 ? '' : 's'}',
-                    style: Theme.of(ctx).textTheme.bodySmall,
-                  ),
-                ],
-              ),
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(ctx),
-              child: const Text('OK'),
-            ),
-          ],
-        ),
-      ),
-    );
   }
 
   @override


### PR DESCRIPTION
Register file type handlers on iOS and Android for .fit, .tcx, .tcx.gz, and .fit.gz files. Users can now open these files directly from the system Files/file manager and the app imports them.

iOS: UTI declarations + CFBundleDocumentTypes in Info.plist; SceneDelegate handles cold/warm starts via security-scoped resources.

Android: Intent-filters matching MIME types and file extensions; MainActivity buffers cold-start intents and resolves content:// URIs.

Flutter: Shared import logic extracted to import_utils.dart; AppShell bridges native file intents via MethodChannel('wattalizer/file_intents').