### PR TITLE
[Build] Remove Android CMake cache to fix utime error

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -147,11 +147,6 @@ jobs:
           key: gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: gradle-
 
-      - uses: actions/cache@v4
-        with:
-          path: /usr/local/lib/android/sdk/cmake
-          key: android-cmake-3.22.1
-
       - name: Pre-install Android CMake
         run: >
           $ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager


### PR DESCRIPTION
Removes the problematic CMake cache step from the Android smoke test job. The cache restore was failing with 'Cannot utime: Operation not permitted' because tar couldn't set timestamps on files in the system-owned /usr/local/lib/android/sdk/cmake directory. CMake installation via sdkmanager is fast enough and the correct way to install SDK components.