### PR TITLE
[Build] Stop Flutter from re-migrating build.gradle.kts

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,7 @@ android {
         applicationId = "com.svenaron.wattalizer"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 21
+        minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName


### PR DESCRIPTION
Use `minSdk = flutter.minSdkVersion` instead of hardcoded `minSdk = 21`.

Flutter's MinSdkVersionMigration tool detects and rewrites hardcoded values (16-23) to `flutter.minSdkVersion` on every `flutter build apk` run. This file modification causes Gradle configuration to re-run even with a valid build cache. Pre-committing the migrated value prevents the migration from firing.