### PR TITLE
Use debug builds in smoke tests

### DIFF
--- a/.github/workflows/smoke_tests.yml
+++ b/.github/workflows/smoke_tests.yml
@@ -37,14 +37,14 @@ jobs:
         if: steps.gen-cache.outputs.cache-hit != 'true'
         run: dart run build_runner build --delete-conflicting-outputs
 
-      - name: Build Linux release
-        run: flutter build linux --release
+      - name: Build Linux debug
+        run: flutter build linux --debug
 
       - name: Launch and verify
         run: >
           xvfb-run --auto-servernum
           timeout 15s
-          ./build/linux/x64/release/bundle/wattalizer
+          ./build/linux/x64/debug/bundle/wattalizer
           || [ $? -eq 124 ]
 
   smoke-windows:
@@ -72,14 +72,14 @@ jobs:
         if: steps.gen-cache.outputs.cache-hit != 'true'
         run: dart run build_runner build --delete-conflicting-outputs
 
-      - name: Build Windows release
-        run: flutter build windows --release
+      - name: Build Windows debug
+        run: flutter build windows --debug
 
       - name: Launch and verify
         shell: pwsh
         run: |
           $p = Start-Process -PassThru `
-            "build\windows\x64\runner\Release\wattalizer.exe"
+            "build\windows\x64\runner\Debug\wattalizer.exe"
           Start-Sleep 10
           if ($p.HasExited -and $p.ExitCode -ne 0) { exit 1 }
           Stop-Process -Id $p.Id -ErrorAction SilentlyContinue
@@ -109,12 +109,12 @@ jobs:
         if: steps.gen-cache.outputs.cache-hit != 'true'
         run: dart run build_runner build --delete-conflicting-outputs
 
-      - name: Build macOS release
-        run: flutter build macos --release
+      - name: Build macOS debug
+        run: flutter build macos --debug
 
       - name: Launch and verify
         run: |
-          "build/macos/Build/Products/Release/Wattalizer.app/Contents/MacOS/wattalizer" &
+          "build/macos/Build/Products/Debug/Wattalizer.app/Contents/MacOS/wattalizer" &
           PID=$!
           sleep 15
           if kill -0 $PID 2>/dev/null; then
@@ -168,10 +168,10 @@ jobs:
         run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Build Android APK
-        run: flutter build apk --release --split-per-abi --target-platform android-arm64
+        run: flutter build apk --debug --split-per-abi --target-platform android-arm64
 
       - name: Verify APK exists
-        run: ls build/app/outputs/flutter-apk/app-arm64-v8a-release.apk
+        run: ls build/app/outputs/flutter-apk/app-arm64-v8a-debug.apk
 
   build-ios:
     runs-on: macos-latest
@@ -199,7 +199,7 @@ jobs:
         run: dart run build_runner build --delete-conflicting-outputs
 
       - name: Build iOS (no codesign)
-        run: flutter build ios --release --no-codesign
+        run: flutter build ios --debug --no-codesign
 
       - name: Verify .app exists
         run: ls build/ios/iphoneos/Runner.app


### PR DESCRIPTION
Switch all five smoke test jobs from --release to --debug. Debug builds skip Dart AOT compilation, which is the main time cost on slow runners like windows-latest. The smoke tests only verify the app launches without crashing, so release mode is unnecessary.