### PR TITLE
Add Smoke Tests badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Wattalizer
 
 [![Build & Test](https://github.com/svenaron/wattalizer/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/svenaron/wattalizer/actions/workflows/ci.yml)
+[![Smoke Tests](https://github.com/svenaron/wattalizer/actions/workflows/smoke_tests.yml/badge.svg?branch=main)](https://github.com/svenaron/wattalizer/actions/workflows/smoke_tests.yml)
 
 A cross-platform mobile app for track cyclists and sprint athletes to analyze power output during sprint interval training.
 


### PR DESCRIPTION
Show status of platform smoke tests (Linux, Windows, macOS, Android, iOS) alongside CI badge.