### PR TITLE
Fix scroll to expanded effort detail

### DIFF
--- a/lib/presentation/screens/ride_detail_screen.dart
+++ b/lib/presentation/screens/ride_detail_screen.dart
@@ -84,6 +84,7 @@ class _DetailView extends StatefulWidget {
 class _DetailViewState extends State<_DetailView> {
   int? _expandedEffort;
   final Map<String, GlobalKey> _effortKeys = {};
+  final Map<String, GlobalKey> _effortExpandedKeys = {};
 
   @override
   void initState() {
@@ -95,7 +96,7 @@ class _DetailViewState extends State<_DetailView> {
       if (match != null) {
         _expandedEffort = match.effortNumber;
         WidgetsBinding.instance.addPostFrameCallback((_) {
-          final key = _effortKeys[match.id];
+          final key = _effortExpandedKeys[match.id];
           if (key?.currentContext != null) {
             unawaited(
               Scrollable.ensureVisible(
@@ -113,12 +114,15 @@ class _DetailViewState extends State<_DetailView> {
 
   void _focusEffort(int effortNumber) {
     setState(() => _expandedEffort = effortNumber);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    // Delay until AnimatedCrossFade (250 ms) has finished expanding before
+    // scrolling, so ensureVisible measures the full expanded height.
+    Future.delayed(const Duration(milliseconds: 280), () {
+      if (!mounted) return;
       final effort = widget.ride.efforts
           .where((e) => e.effortNumber == effortNumber)
           .firstOrNull;
       if (effort == null) return;
-      final key = _effortKeys[effort.id];
+      final key = _effortExpandedKeys[effort.id];
       if (key?.currentContext != null) {
         unawaited(
           Scrollable.ensureVisible(
@@ -193,6 +197,7 @@ class _DetailViewState extends State<_DetailView> {
               // Effort cards
               ...ride.efforts.map((e) {
                 _effortKeys.putIfAbsent(e.id, GlobalKey.new);
+                _effortExpandedKeys.putIfAbsent(e.id, GlobalKey.new);
                 return Padding(
                   key: _effortKeys[e.id],
                   padding: const EdgeInsets.only(bottom: 8),
@@ -206,6 +211,7 @@ class _DetailViewState extends State<_DetailView> {
                           : e.effortNumber;
                     }),
                     onDelete: () => _deleteEffort(ride, e.effortNumber),
+                    expandedBodyKey: _effortExpandedKeys[e.id],
                   ),
                 );
               }),

--- a/lib/presentation/widgets/effort_card.dart
+++ b/lib/presentation/widgets/effort_card.dart
@@ -12,6 +12,7 @@ class EffortCard extends StatelessWidget {
     this.isExpanded = false,
     this.onToggle,
     this.onDelete,
+    this.expandedBodyKey,
     super.key,
   });
 
@@ -20,6 +21,7 @@ class EffortCard extends StatelessWidget {
   final bool isExpanded;
   final VoidCallback? onToggle;
   final VoidCallback? onDelete;
+  final Key? expandedBodyKey;
 
   @override
   Widget build(BuildContext context) {
@@ -86,6 +88,7 @@ class EffortCard extends StatelessWidget {
 
   Widget _expanded(EffortSummary s) {
     return Padding(
+      key: expandedBodyKey,
       padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
When tapping an effort in the timeline or navigating from the PDC screen,
the scroll now targets the expanded detail content (chart + stats) instead
of just the card header. Added expandedBodyKey to EffortCard and a second
key map in RideDetailScreen. _focusEffort now delays 280ms before scrolling
to account for the 250ms AnimatedCrossFade animation.