### PR TITLE
[GUI] Compute ride PDC on-demand from efforts

### DIFF
--- a/lib/presentation/providers/ride_pdc_provider.dart
+++ b/lib/presentation/providers/ride_pdc_provider.dart
@@ -2,11 +2,42 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/domain/models/map_curve.dart';
 import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
 
-/// Loads the ride-level PDC (power duration curve) for a single ride.
+/// Computes the ride-level PDC on demand by taking the max power at each
+/// duration across all stored effort curves.
 /// autoDispose — released when no widget needs it (e.g. card scrolled off).
 // ignore: specify_nonobvious_property_types
 final ridePdcProvider =
     FutureProvider.autoDispose.family<MapCurve?, String>((ref, rideId) async {
   final repo = ref.read(rideRepositoryProvider);
-  return repo.getRidePdc(rideId);
+  final efforts = await repo.getEfforts(rideId);
+  if (efforts.isEmpty) return null;
+
+  final values = List<double>.filled(90, 0);
+  final flags = List<MapCurveFlags>.filled(90, const MapCurveFlags());
+
+  for (final effort in efforts) {
+    final curve = effort.mapCurve;
+    for (var i = 0; i < 90; i++) {
+      if (curve.values[i] > values[i]) {
+        values[i] = curve.values[i];
+        flags[i] = curve.flags[i];
+      }
+    }
+  }
+
+  // Enforce monotonicity (sweep right-to-left)
+  for (var i = 88; i >= 0; i--) {
+    if (values[i] < values[i + 1]) {
+      values[i] = values[i + 1];
+    }
+  }
+
+  if (values.every((v) => v == 0.0)) return null;
+
+  return MapCurve(
+    entityId: rideId,
+    values: values,
+    flags: flags,
+    computedAt: DateTime.now().toUtc(),
+  );
 });

--- a/test/presentation/fixtures/fake_repository.dart
+++ b/test/presentation/fixtures/fake_repository.dart
@@ -28,6 +28,7 @@ class FakeRepository implements RideRepository {
   List<DeviceInfo> devicesToReturn = [];
   Map<String, Ride> ridesById = {};
   Map<String, MapCurve> ridePdcs = {};
+  Map<String, List<Effort>> effortsByRide = {};
   AutoLapConfig defaultConfigToReturn = const AutoLapConfig(
     id: 1,
     name: 'Default',
@@ -94,7 +95,8 @@ class FakeRepository implements RideRepository {
   }
 
   @override
-  Future<List<Effort>> getEfforts(String rideId) async => [];
+  Future<List<Effort>> getEfforts(String rideId) async =>
+      effortsByRide[rideId] ?? [];
 
   @override
   Future<void> saveEfforts(String rideId, List<Effort> efforts) async {

--- a/test/presentation/providers/ride_pdc_provider_test.dart
+++ b/test/presentation/providers/ride_pdc_provider_test.dart
@@ -1,13 +1,37 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/models/effort.dart';
+import 'package:wattalizer/domain/models/effort_summary.dart';
 import 'package:wattalizer/domain/models/map_curve.dart';
 import 'package:wattalizer/presentation/providers/ride_pdc_provider.dart';
 
 import '../fixtures/fake_repository.dart';
 import '../fixtures/test_container.dart';
 
+Effort _effort(String id, String rideId, List<double> values) {
+  return Effort(
+    id: id,
+    rideId: rideId,
+    effortNumber: 1,
+    startOffset: 0,
+    endOffset: 30,
+    type: EffortType.auto,
+    summary: const EffortSummary(
+      durationSeconds: 30,
+      avgPower: 0,
+      peakPower: 0,
+    ),
+    mapCurve: MapCurve(
+      entityId: id,
+      values: values,
+      flags: List.generate(90, (_) => const MapCurveFlags()),
+      computedAt: DateTime(2025),
+    ),
+  );
+}
+
 void main() {
   group('ridePdcProvider', () {
-    test('returns null when no PDC stored', () async {
+    test('returns null when no efforts stored', () async {
       final container = createTestContainer(repository: FakeRepository());
       addTearDown(container.dispose);
 
@@ -16,15 +40,12 @@ void main() {
       expect(pdc, isNull);
     });
 
-    test('returns PDC when available', () async {
+    test('returns PDC derived from effort curves', () async {
       final repo = FakeRepository()
-        ..ridePdcs = {
-          'r1': MapCurve(
-            entityId: 'r1',
-            values: List.generate(90, (i) => 500.0 - i * 2),
-            flags: List.generate(90, (_) => const MapCurveFlags()),
-            computedAt: DateTime(2025),
-          ),
+        ..effortsByRide = {
+          'r1': [
+            _effort('e1', 'r1', List.generate(90, (i) => 500.0 - i * 2)),
+          ],
         };
       final container = createTestContainer(repository: repo);
       addTearDown(container.dispose);
@@ -36,21 +57,32 @@ void main() {
       expect(pdc.values[0], 500.0);
     });
 
-    test('family parameter routes to correct ride PDC', () async {
+    test('takes max power across multiple efforts at each duration', () async {
       final repo = FakeRepository()
-        ..ridePdcs = {
-          'r1': MapCurve(
-            entityId: 'r1',
-            values: List.generate(90, (_) => 500.0),
-            flags: List.generate(90, (_) => const MapCurveFlags()),
-            computedAt: DateTime(2025),
-          ),
-          'r2': MapCurve(
-            entityId: 'r2',
-            values: List.generate(90, (_) => 700.0),
-            flags: List.generate(90, (_) => const MapCurveFlags()),
-            computedAt: DateTime(2025),
-          ),
+        ..effortsByRide = {
+          'r1': [
+            _effort('e1', 'r1', List.generate(90, (_) => 400.0)),
+            _effort('e2', 'r1', List.generate(90, (_) => 600.0)),
+          ],
+        };
+      final container = createTestContainer(repository: repo);
+      addTearDown(container.dispose);
+
+      final pdc = await container.read(ridePdcProvider('r1').future);
+
+      expect(pdc!.values[0], 600.0);
+      expect(pdc.values[89], 600.0);
+    });
+
+    test('family parameter routes to correct ride efforts', () async {
+      final repo = FakeRepository()
+        ..effortsByRide = {
+          'r1': [
+            _effort('e1', 'r1', List.generate(90, (_) => 500.0)),
+          ],
+          'r2': [
+            _effort('e2', 'r2', List.generate(90, (_) => 700.0)),
+          ],
         };
       final container = createTestContainer(repository: repo);
       addTearDown(container.dispose);
@@ -60,6 +92,24 @@ void main() {
 
       expect(pdc1!.values[0], 500.0);
       expect(pdc2!.values[0], 700.0);
+    });
+
+    test('enforces monotonicity on computed PDC', () async {
+      // Non-monotonic input: 300 at 1s, 400 at 2s (should be flattened)
+      final nonMono = List<double>.filled(90, 100);
+      nonMono[0] = 300.0;
+      nonMono[1] = 400.0; // higher than 1s — monotonicity fix needed
+      final repo = FakeRepository()
+        ..effortsByRide = {
+          'r1': [_effort('e1', 'r1', nonMono)],
+        };
+      final container = createTestContainer(repository: repo);
+      addTearDown(container.dispose);
+
+      final pdc = await container.read(ridePdcProvider('r1').future);
+
+      // After monotonicity sweep, values[0] should be >= values[1]
+      expect(pdc!.values[0], greaterThanOrEqualTo(pdc.values[1]));
     });
   });
 }


### PR DESCRIPTION
Ride detail screen PDC chart was invisible because `saveRidePdc()` was never called from production code. The provider tried to load a non-existent stored ride PDC.

Fixed by deriving PDC on-demand: takes max power at each duration across all effort curves and enforces monotonicity. Aligns with architecture doc ("derived on demand... not stored separately").

This also fixes sparklines on history cards (same underlying issue).

All 401 tests pass.