### PR TITLE
[Fix] Effort end includes confirmation window

### DIFF
--- a/lib/domain/services/autolap_detector.dart
+++ b/lib/domain/services/autolap_detector.dart
@@ -178,10 +178,10 @@ class AutoLapDetector {
           _inEffortTrailing.clear();
           _peakWatts = null;
 
-          final duration = _tentativeEndOffset - _tentativeStartOffset;
+          final duration = offset - _tentativeStartOffset;
           return EffortEndedEvent(
             startOffset: _tentativeStartOffset,
-            endOffset: _tentativeEndOffset,
+            endOffset: offset,
             isManual: false,
             wasTooShort: duration < config.minEffortSeconds,
             wasTooWeak:
@@ -254,7 +254,7 @@ class AutoLapDetector {
         return [
           EffortEndedEvent(
             startOffset: _tentativeStartOffset,
-            endOffset: _tentativeEndOffset,
+            endOffset: currentOffset,
             isManual: true,
             wasTooShort: false,
             wasTooWeak: false,
@@ -294,7 +294,7 @@ class AutoLapDetector {
         _peakWatts = null;
         return EffortEndedEvent(
           startOffset: _tentativeStartOffset,
-          endOffset: _tentativeEndOffset,
+          endOffset: currentOffset,
           isManual: false,
           wasTooShort: false,
           wasTooWeak:

--- a/test/domain/autolap_detector_test.dart
+++ b/test/domain/autolap_detector_test.dart
@@ -76,7 +76,7 @@ void main() {
       expect(ev, isA<EffortEndedEvent>());
       final ended = ev! as EffortEndedEvent;
       expect(ended.startOffset, 5);
-      expect(ended.endOffset, 12); // trimmed to tentative end
+      expect(ended.endOffset, 14); // confirmed at t=14 (drop at t=12 + 2 more)
       expect(ended.wasTooShort, false);
       expect(ended.isManual, false);
       expect(detector.currentState, AutoLapState.idle);
@@ -315,7 +315,7 @@ void main() {
 
         final ev = detector.endRide(15);
         expect(ev, isA<EffortEndedEvent>());
-        expect((ev! as EffortEndedEvent).endOffset, 10); // trimmed to tentative
+        expect((ev! as EffortEndedEvent).endOffset, 15); // ride ended at t=15
       },
     );
   });
@@ -385,7 +385,7 @@ void main() {
       expect(events.length, 1);
       expect(events[0], isA<EffortEndedEvent>());
       final ended = events[0] as EffortEndedEvent;
-      expect(ended.endOffset, 10); // trimmed to tentative
+      expect(ended.endOffset, 15); // manualLap at t=15
       expect(ended.isManual, true);
       expect(detector.currentState, AutoLapState.idle);
     });


### PR DESCRIPTION
When an effort ends, endOffset is now set to the current timestamp when confirmation completes, rather than when the power drop is first detected. This fixes a bug where endConfirmSeconds-1 seconds of sprint data were silently discarded.

For example, with Standing Start (endConfirmSeconds=4), efforts were ending 3 seconds too early. The confirmation window is now symmetric with start detection behavior.

Changes: AutoLapDetector.pendingEnd state + endRide/manualLap in pendingEnd use current offset. Tests updated to expect correct behavior.