### PR TITLE
Multi-athlete profile support

### DIFF
--- a/lib/core/error_types.dart
+++ b/lib/core/error_types.dart
@@ -59,3 +59,9 @@ class InvalidConfigError extends AppError {
   final String field;
   final String reason;
 }
+
+// --- Athletes ---
+
+class AthleteDeleteRefused extends AppError {
+  AthleteDeleteRefused();
+}

--- a/lib/data/database/database.dart
+++ b/lib/data/database/database.dart
@@ -10,6 +10,7 @@ part 'database.g.dart';
 
 @DriftDatabase(
   tables: [
+    Athletes,
     Rides,
     RideTags,
     Efforts,
@@ -32,13 +33,12 @@ class AppDatabase extends _$AppDatabase {
   }
 
   @override
-  int get schemaVersion => 4;
+  int get schemaVersion => 5;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
         onCreate: (m) async {
           await m.createAll();
-          // Custom composite / covering indexes not expressible in table DSL
           await m.database.customStatement(
             'CREATE INDEX idx_readings_ride_offset '
             'ON readings (ride_id, offset_seconds)',
@@ -59,22 +59,35 @@ class AppDatabase extends _$AppDatabase {
             'CREATE INDEX idx_ride_tags_tag '
             'ON ride_tags (tag)',
           );
+          await _seedDefaultAthlete(m.database);
           await _seedBuiltInConfigs(m.database);
         },
         onUpgrade: (m, from, to) async {
-          if (from < 4) {
-            // Drop and recreate all tables (no user data yet in prod).
+          if (from < 5) {
             for (final entity in allSchemaEntities.toList().reversed) {
               await m.drop(entity);
             }
             await m.createAll();
+            await _seedDefaultAthlete(m.database);
             await _seedBuiltInConfigs(m.database);
             return;
           }
         },
       );
 
-  static Future<void> _seedBuiltInConfigs(DatabaseConnectionUser db) async {
+  static Future<void> _seedDefaultAthlete(
+    DatabaseConnectionUser db,
+  ) async {
+    await db.customStatement(
+      'INSERT INTO athletes (id, name, created_at) '
+      "VALUES ('me', 'Me', "
+      '${DateTime.now().millisecondsSinceEpoch})',
+    );
+  }
+
+  static Future<void> _seedBuiltInConfigs(
+    DatabaseConnectionUser db,
+  ) async {
     const cols = 'INSERT INTO autolap_configs '
         '(name, start_delta_watts, '
         'start_confirm_seconds, start_dropout_tolerance, '
@@ -82,13 +95,16 @@ class AppDatabase extends _$AppDatabase {
         'pre_effort_baseline_window, in_effort_trailing_window, '
         'min_peak_watts, is_default) VALUES ';
     await db.customStatement(
-      "$cols('Standing Start', 350.0, 1, 1, 250.0, 4, 2, 10, 5, 700.0, 1)",
+      "$cols('Standing Start', 350.0, 1, 1, "
+      '250.0, 4, 2, 10, 5, 700.0, 1)',
     );
     await db.customStatement(
-      "$cols('Flying Start', 150.0, 2, 1, 150.0, 5, 5, 15, 8, 700.0, 0)",
+      "$cols('Flying Start', 150.0, 2, 1, "
+      '150.0, 5, 5, 15, 8, 700.0, 0)',
     );
     await db.customStatement(
-      "$cols('Broad', 120.0, 1, 1, 100.0, 3, 2, 15, 8, 400.0, 0)",
+      "$cols('Broad', 120.0, 1, 1, "
+      '100.0, 3, 2, 15, 8, 400.0, 0)',
     );
   }
 }

--- a/lib/data/database/local_athlete_repository.dart
+++ b/lib/data/database/local_athlete_repository.dart
@@ -1,0 +1,69 @@
+import 'package:drift/drift.dart';
+import 'package:wattalizer/core/error_types.dart';
+import 'package:wattalizer/data/database/database.dart';
+import 'package:wattalizer/data/database/local_ride_repository.dart';
+import 'package:wattalizer/domain/interfaces/athlete_repository.dart';
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+
+class LocalAthleteRepository implements AthleteRepository {
+  LocalAthleteRepository(this._db, this._rides);
+  final AppDatabase _db;
+  final LocalRideRepository _rides;
+
+  @override
+  Future<List<AthleteProfile>> getAthletes() async {
+    final rows = await (_db.select(_db.athletes)
+          ..orderBy([(t) => OrderingTerm.asc(t.name)]))
+        .get();
+    return rows.map(AthleteProfile.fromRow).toList();
+  }
+
+  @override
+  Future<AthleteProfile?> getAthlete(String id) async {
+    final row = await (_db.select(_db.athletes)..where((t) => t.id.equals(id)))
+        .getSingleOrNull();
+    return row != null ? AthleteProfile.fromRow(row) : null;
+  }
+
+  @override
+  Future<void> saveAthlete(AthleteProfile athlete) async {
+    await _db.into(_db.athletes).insert(athlete.toCompanion());
+  }
+
+  @override
+  Future<void> updateAthlete(AthleteProfile athlete) async {
+    await (_db.update(_db.athletes)..where((t) => t.id.equals(athlete.id)))
+        .write(AthletesCompanion(name: Value(athlete.name)));
+  }
+
+  @override
+  Future<void> deleteAthlete(String id) async {
+    await _db.transaction(() async {
+      final count = await _db
+          .customSelect('SELECT COUNT(*) AS c FROM athletes')
+          .getSingle();
+      if (count.read<int>('c') <= 1) {
+        throw AthleteDeleteRefused();
+      }
+
+      // Cascade: delete all rides (and their children) for this athlete
+      final rideRows = await (_db.select(_db.rides)
+            ..where((t) => t.athleteId.equals(id)))
+          .get();
+      for (final ride in rideRows) {
+        await _rides.deleteRide(ride.id);
+      }
+
+      // Delete athlete-scoped devices
+      await (_db.delete(_db.devices)..where((t) => t.athleteId.equals(id)))
+          .go();
+
+      // Delete athlete-scoped autolap configs
+      await (_db.delete(_db.autolapConfigs)
+            ..where((t) => t.athleteId.equals(id)))
+          .go();
+
+      await (_db.delete(_db.athletes)..where((t) => t.id.equals(id))).go();
+    });
+  }
+}

--- a/lib/data/database/local_ride_repository.dart
+++ b/lib/data/database/local_ride_repository.dart
@@ -723,4 +723,345 @@ class LocalRideRepository implements RideRepository {
       );
     }
   }
+
+  // --- Athlete-scoped variants ---
+
+  Future<int> getRideCountForAthlete(String athleteId) async {
+    final result = await _db.customSelect(
+      'SELECT COUNT(*) AS c FROM rides WHERE athlete_id = ?',
+      variables: [Variable.withString(athleteId)],
+    ).getSingle();
+    return result.read<int>('c');
+  }
+
+  Future<void> saveRideForAthlete(Ride ride, String athleteId) async {
+    try {
+      await _db.transaction(() async {
+        final companion = ride.toCompanion();
+        await _db.into(_db.rides).insert(
+              companion.copyWith(athleteId: Value(athleteId)),
+            );
+        final tagCompanions = _buildTagCompanions(ride.id, ride.tags);
+        if (tagCompanions.isNotEmpty) {
+          await _db.batch((b) {
+            b.insertAll(_db.rideTags, tagCompanions);
+          });
+        }
+      });
+    } catch (e) {
+      throw DatabaseError(operation: 'save_ride', detail: e.toString());
+    }
+  }
+
+  Future<List<RideSummaryRow>> getRidesForAthlete(
+    String athleteId, {
+    DateTime? from,
+    DateTime? to,
+    Set<String>? tags,
+    int? limit,
+    int offset = 0,
+  }) async {
+    try {
+      Set<String>? allowedRideIds;
+      if (tags != null && tags.isNotEmpty) {
+        allowedRideIds = await _getRideIdsWithAllTags(tags);
+        if (allowedRideIds.isEmpty) return [];
+      }
+
+      final query = _db.select(_db.rides)
+        ..where((t) {
+          final conditions = <Expression<bool>>[
+            t.athleteId.equals(athleteId),
+          ];
+          if (from != null) {
+            conditions.add(t.startTime.isBiggerOrEqualValue(from));
+          }
+          if (to != null) {
+            conditions.add(t.startTime.isSmallerOrEqualValue(to));
+          }
+          if (allowedRideIds != null) {
+            conditions.add(t.id.isIn(allowedRideIds.toList()));
+          }
+          return Expression.and(conditions);
+        })
+        ..orderBy([(t) => OrderingTerm.desc(t.startTime)]);
+
+      if (limit != null) {
+        query.limit(limit, offset: offset > 0 ? offset : null);
+      } else if (offset > 0) {
+        query.limit(-1, offset: offset);
+      }
+
+      final rows = await query.get();
+      if (rows.isEmpty) return [];
+
+      final rideIds = rows.map((r) => r.id).toList();
+      final allTagRows = await (_db.select(
+        _db.rideTags,
+      )..where((t) => t.rideId.isIn(rideIds)))
+          .get();
+      final tagsByRide = <String, List<String>>{};
+      for (final tagRow in allTagRows) {
+        tagsByRide.putIfAbsent(tagRow.rideId, () => []).add(tagRow.tag);
+      }
+
+      return rows.map((row) {
+        return RideSummaryRow(
+          id: row.id,
+          startTime: row.startTime,
+          tags: tagsByRide[row.id] ?? [],
+          summary: _summaryFromRow(row),
+        );
+      }).toList();
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'get_rides',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<List<MapCurveWithProvenance>> getAllEffortCurvesForAthlete(
+    String athleteId, {
+    DateTime? from,
+    DateTime? to,
+    Set<String>? tags,
+  }) async {
+    try {
+      Set<String>? allowedRideIds;
+      if (tags != null && tags.isNotEmpty) {
+        allowedRideIds = await _getRideIdsWithAllTags(tags);
+        if (allowedRideIds.isEmpty) return [];
+      }
+
+      final join = _db.select(_db.efforts).join([
+        innerJoin(
+          _db.rides,
+          _db.rides.id.equalsExp(_db.efforts.rideId),
+        ),
+      ]);
+
+      final conditions = <Expression<bool>>[
+        _db.rides.athleteId.equals(athleteId),
+      ];
+      if (from != null) {
+        conditions.add(
+          _db.rides.startTime.isBiggerOrEqualValue(from),
+        );
+      }
+      if (to != null) {
+        conditions.add(
+          _db.rides.startTime.isSmallerOrEqualValue(to),
+        );
+      }
+      if (allowedRideIds != null) {
+        conditions.add(
+          _db.efforts.rideId.isIn(allowedRideIds.toList()),
+        );
+      }
+      join.where(Expression.and(conditions));
+
+      final joinRows = await join.get();
+      if (joinRows.isEmpty) return [];
+
+      final provenanceList = joinRows.map((row) {
+        final effort = row.readTable(_db.efforts);
+        final ride = row.readTable(_db.rides);
+        return (
+          effortId: effort.id,
+          effortNumber: effort.effortNumber,
+          rideId: ride.id,
+          rideDate: ride.startTime,
+        );
+      }).toList();
+
+      final effortIds = provenanceList.map((p) => p.effortId).toList();
+      final curveRows = await (_db.select(
+        _db.mapCurves,
+      )..where((t) => t.effortId.isIn(effortIds)))
+          .get();
+
+      final curvesByEffort = <String, List<MapCurveRow>>{};
+      for (final row in curveRows) {
+        curvesByEffort.putIfAbsent(row.effortId, () => []).add(row);
+      }
+
+      return provenanceList
+          .where((p) => curvesByEffort.containsKey(p.effortId))
+          .map(
+            (p) => MapCurveWithProvenance(
+              effortId: p.effortId,
+              rideId: p.rideId,
+              rideDate: p.rideDate,
+              effortNumber: p.effortNumber,
+              curve: MapCurve.fromRows(
+                p.effortId,
+                curvesByEffort[p.effortId]!,
+              ),
+            ),
+          )
+          .toList();
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'get_all_effort_curves',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<List<String>> getAllTagsForAthlete(String athleteId) async {
+    try {
+      final rows = await _db.customSelect(
+        'SELECT DISTINCT rt.tag FROM ride_tags rt '
+        'INNER JOIN rides r ON r.id = rt.ride_id '
+        'WHERE r.athlete_id = ? '
+        'ORDER BY rt.tag ASC',
+        variables: [Variable.withString(athleteId)],
+      ).get();
+      return rows.map((r) => r.read<String>('tag')).toList();
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'get_all_tags',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<List<DeviceInfo>> getRememberedDevicesForAthlete(
+    String athleteId,
+  ) async {
+    try {
+      final rows = await (_db.select(_db.devices)
+            ..where((t) => t.athleteId.equals(athleteId)))
+          .get();
+      return rows.map(DeviceInfo.fromRow).toList();
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'get_remembered_devices',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<void> saveDeviceForAthlete(
+    DeviceInfo device,
+    String athleteId,
+  ) async {
+    try {
+      final companion = device.toCompanion();
+      await _db.into(_db.devices).insertOnConflictUpdate(
+            companion.copyWith(athleteId: Value(athleteId)),
+          );
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'save_device',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<List<DeviceInfo>> getAutoConnectDevicesForAthlete(
+    String athleteId,
+  ) async {
+    try {
+      final rows = await (_db.select(_db.devices)
+            ..where(
+              (t) => t.athleteId.equals(athleteId) & t.autoConnect.equals(true),
+            ))
+          .get();
+      return rows.map(DeviceInfo.fromRow).toList();
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'get_auto_connect_devices',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<List<AutoLapConfig>> getAutoLapConfigsForAthlete(
+    String athleteId,
+  ) async {
+    try {
+      final rows = await (_db.select(_db.autolapConfigs)
+            ..where(
+              (t) => t.athleteId.isNull() | t.athleteId.equals(athleteId),
+            ))
+          .get();
+      return rows.map(AutoLapConfig.fromRow).toList();
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'get_autolap_configs',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<AutoLapConfig> getDefaultConfigForAthlete(
+    String athleteId,
+  ) async {
+    try {
+      // Prefer athlete-specific default first
+      final athleteDefault = await (_db.select(_db.autolapConfigs)
+            ..where(
+              (t) => t.athleteId.equals(athleteId) & t.isDefault.equals(true),
+            ))
+          .getSingleOrNull();
+      if (athleteDefault != null) {
+        return AutoLapConfig.fromRow(athleteDefault);
+      }
+      // Fall back to global default
+      final globalDefault = await (_db.select(_db.autolapConfigs)
+            ..where(
+              (t) => t.athleteId.isNull() & t.isDefault.equals(true),
+            ))
+          .getSingleOrNull();
+      return globalDefault != null
+          ? AutoLapConfig.fromRow(globalDefault)
+          : AutoLapConfig.standingStart();
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'get_default_config',
+        detail: e.toString(),
+      );
+    }
+  }
+
+  Future<int> saveAutoLapConfigForAthlete(
+    AutoLapConfig config,
+    String athleteId,
+  ) async {
+    try {
+      return await _db.transaction(() async {
+        if (config.isDefault) {
+          // Clear isDefault only for this athlete's configs
+          await (_db.update(_db.autolapConfigs)
+                ..where(
+                  (t) =>
+                      t.athleteId.equals(athleteId) & t.isDefault.equals(true),
+                ))
+              .write(
+            const AutolapConfigsCompanion(isDefault: Value(false)),
+          );
+        }
+        final companion = config.toCompanion();
+        if (config.id == null) {
+          return _db.into(_db.autolapConfigs).insert(
+                companion.copyWith(athleteId: Value(athleteId)),
+              );
+        } else {
+          await (_db.update(_db.autolapConfigs)
+                ..where((t) => t.id.equals(config.id!)))
+              .write(
+            companion.copyWith(athleteId: Value(athleteId)),
+          );
+          return config.id!;
+        }
+      });
+    } catch (e) {
+      throw DatabaseError(
+        operation: 'save_autolap_config',
+        detail: e.toString(),
+      );
+    }
+  }
 }

--- a/lib/data/database/scoped_ride_repository.dart
+++ b/lib/data/database/scoped_ride_repository.dart
@@ -1,0 +1,148 @@
+import 'package:wattalizer/data/database/local_ride_repository.dart';
+import 'package:wattalizer/domain/interfaces/ride_repository.dart';
+import 'package:wattalizer/domain/models/autolap_config.dart';
+import 'package:wattalizer/domain/models/device_info.dart';
+import 'package:wattalizer/domain/models/effort.dart';
+import 'package:wattalizer/domain/models/map_curve.dart';
+import 'package:wattalizer/domain/models/ride.dart';
+import 'package:wattalizer/domain/models/sensor_reading.dart';
+
+/// Thin wrapper around [LocalRideRepository] that scopes all
+/// athlete-sensitive operations to a fixed athlete ID.
+/// Non-scoped operations (by global ID) delegate directly.
+class ScopedRideRepository implements RideRepository {
+  ScopedRideRepository(this._inner, this._athleteId);
+  final LocalRideRepository _inner;
+  final String _athleteId;
+
+  @override
+  Future<void> transaction(Future<void> Function() work) =>
+      _inner.transaction(work);
+
+  @override
+  Future<int> getRideCount() => _inner.getRideCountForAthlete(_athleteId);
+
+  @override
+  Future<void> saveRide(Ride ride) =>
+      _inner.saveRideForAthlete(ride, _athleteId);
+
+  @override
+  Future<void> updateRide(Ride ride) => _inner.updateRide(ride);
+
+  @override
+  Future<Ride?> getRide(String id) => _inner.getRide(id);
+
+  @override
+  Future<List<RideSummaryRow>> getRides({
+    DateTime? from,
+    DateTime? to,
+    Set<String>? tags,
+    int? limit,
+    int offset = 0,
+  }) =>
+      _inner.getRidesForAthlete(
+        _athleteId,
+        from: from,
+        to: to,
+        tags: tags,
+        limit: limit,
+        offset: offset,
+      );
+
+  @override
+  Future<void> deleteRide(String id) => _inner.deleteRide(id);
+
+  @override
+  Future<List<SensorReading>> getReadings(
+    String rideId, {
+    int? startOffset,
+    int? endOffset,
+  }) =>
+      _inner.getReadings(
+        rideId,
+        startOffset: startOffset,
+        endOffset: endOffset,
+      );
+
+  @override
+  Future<void> insertReadings(
+    String rideId,
+    List<SensorReading> readings,
+  ) =>
+      _inner.insertReadings(rideId, readings);
+
+  @override
+  Future<List<Effort>> getEfforts(String rideId) => _inner.getEfforts(rideId);
+
+  @override
+  Future<void> saveEfforts(String rideId, List<Effort> efforts) =>
+      _inner.saveEfforts(rideId, efforts);
+
+  @override
+  Future<void> deleteEfforts(String rideId) => _inner.deleteEfforts(rideId);
+
+  @override
+  Future<void> saveMapCurve(String entityId, MapCurve curve) =>
+      _inner.saveMapCurve(entityId, curve);
+
+  @override
+  Future<MapCurve?> getMapCurve(String entityId) =>
+      _inner.getMapCurve(entityId);
+
+  @override
+  Future<List<MapCurve>> getMapCurvesForRide(String rideId) =>
+      _inner.getMapCurvesForRide(rideId);
+
+  @override
+  Future<List<MapCurveWithProvenance>> getAllEffortCurves({
+    DateTime? from,
+    DateTime? to,
+    Set<String>? tags,
+  }) =>
+      _inner.getAllEffortCurvesForAthlete(
+        _athleteId,
+        from: from,
+        to: to,
+        tags: tags,
+      );
+
+  @override
+  Future<List<String>> getAllTags() => _inner.getAllTagsForAthlete(_athleteId);
+
+  @override
+  Future<void> saveRidePdc(String rideId, MapCurve curve) =>
+      _inner.saveRidePdc(rideId, curve);
+
+  @override
+  Future<MapCurve?> getRidePdc(String rideId) => _inner.getRidePdc(rideId);
+
+  @override
+  Future<List<AutoLapConfig>> getAutoLapConfigs() =>
+      _inner.getAutoLapConfigsForAthlete(_athleteId);
+
+  @override
+  Future<AutoLapConfig> getDefaultConfig() =>
+      _inner.getDefaultConfigForAthlete(_athleteId);
+
+  @override
+  Future<int> saveAutoLapConfig(AutoLapConfig config) =>
+      _inner.saveAutoLapConfigForAthlete(config, _athleteId);
+
+  @override
+  Future<bool> deleteAutoLapConfig(int id) => _inner.deleteAutoLapConfig(id);
+
+  @override
+  Future<List<DeviceInfo>> getRememberedDevices() =>
+      _inner.getRememberedDevicesForAthlete(_athleteId);
+
+  @override
+  Future<void> saveDevice(DeviceInfo device) =>
+      _inner.saveDeviceForAthlete(device, _athleteId);
+
+  @override
+  Future<void> deleteDevice(String deviceId) => _inner.deleteDevice(deviceId);
+
+  @override
+  Future<List<DeviceInfo>> getAutoConnectDevices() =>
+      _inner.getAutoConnectDevicesForAthlete(_athleteId);
+}

--- a/lib/data/database/tables.dart
+++ b/lib/data/database/tables.dart
@@ -1,8 +1,20 @@
 import 'package:drift/drift.dart';
 
+@DataClassName('AthleteRow')
+class Athletes extends Table {
+  TextColumn get id => text()();
+  TextColumn get name => text()();
+  DateTimeColumn get createdAt => dateTime()();
+  TextColumn get coachId => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
 @DataClassName('RideRow')
 class Rides extends Table {
   TextColumn get id => text()();
+  TextColumn get athleteId => text().withDefault(const Constant('me'))();
   DateTimeColumn get startTime => dateTime()();
   DateTimeColumn get endTime => dateTime().nullable()();
   TextColumn get notes => text().nullable()();
@@ -100,8 +112,9 @@ class AppSettings extends Table {
 @DataClassName('DeviceRow')
 class Devices extends Table {
   TextColumn get deviceId => text()();
+  TextColumn get athleteId => text().withDefault(const Constant('me'))();
   TextColumn get displayName => text()();
-  TextColumn get supportedServices => text()(); // JSON: '["power","heartRate"]'
+  TextColumn get supportedServices => text()(); // JSON
   DateTimeColumn get lastConnected => dateTime()();
   BoolColumn get autoConnect => boolean().withDefault(const Constant(true))();
 
@@ -112,6 +125,7 @@ class Devices extends Table {
 @DataClassName('AutolapConfigRow')
 class AutolapConfigs extends Table {
   IntColumn get id => integer().autoIncrement()();
+  TextColumn get athleteId => text().nullable()();
   TextColumn get name => text()();
   RealColumn get startDeltaWatts => real()();
   IntColumn get startConfirmSeconds =>

--- a/lib/domain/interfaces/athlete_repository.dart
+++ b/lib/domain/interfaces/athlete_repository.dart
@@ -1,0 +1,13 @@
+import 'package:wattalizer/core/error_types.dart' show AthleteDeleteRefused;
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+
+abstract class AthleteRepository {
+  Future<List<AthleteProfile>> getAthletes();
+  Future<AthleteProfile?> getAthlete(String id);
+  Future<void> saveAthlete(AthleteProfile athlete);
+  Future<void> updateAthlete(AthleteProfile athlete);
+
+  /// Throws [AthleteDeleteRefused] if this is the last athlete.
+  /// Cascade-deletes all rides belonging to this athlete.
+  Future<void> deleteAthlete(String id);
+}

--- a/lib/domain/models/athlete_profile.dart
+++ b/lib/domain/models/athlete_profile.dart
@@ -1,0 +1,37 @@
+import 'package:drift/drift.dart';
+import 'package:wattalizer/data/database/database.dart';
+
+class AthleteProfile {
+  const AthleteProfile({
+    required this.id,
+    required this.name,
+    required this.createdAt,
+    this.coachId,
+  });
+
+  factory AthleteProfile.fromRow(AthleteRow row) => AthleteProfile(
+        id: row.id,
+        name: row.name,
+        createdAt: row.createdAt,
+        coachId: row.coachId,
+      );
+
+  AthletesCompanion toCompanion() => AthletesCompanion.insert(
+        id: id,
+        name: name,
+        createdAt: createdAt,
+        coachId: Value.absentIfNull(coachId),
+      );
+
+  AthleteProfile copyWith({String? name}) => AthleteProfile(
+        id: id,
+        name: name ?? this.name,
+        createdAt: createdAt,
+        coachId: coachId,
+      );
+
+  final String id;
+  final String name;
+  final DateTime createdAt;
+  final String? coachId;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,20 +3,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/data/database/database.dart';
+import 'package:wattalizer/data/database/local_athlete_repository.dart';
 import 'package:wattalizer/data/database/local_ride_repository.dart';
+import 'package:wattalizer/presentation/providers/athlete_repository_provider.dart';
 import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
 import 'package:wattalizer/presentation/providers/theme_mode_provider.dart';
 import 'package:wattalizer/presentation/screens/app_shell.dart';
 
 void main() async {
-  // Suppress a known Flutter macOS embedding bug where modifier keys (Meta/Cmd)
-  // get stuck in "pressed" state after the app loses focus mid-keypress (e.g.
-  // Cmd+Tab to another app). Flutter never receives the key-up, so when Cmd is
-  // pressed again on return it fires an assertion in HardwareKeyboard.
+  // Suppress a known Flutter macOS embedding bug where modifier keys
+  // (Meta/Cmd) get stuck in "pressed" state after the app loses focus
+  // mid-keypress (e.g. Cmd+Tab to another app). Flutter never receives
+  // the key-up, so when Cmd is pressed again on return it fires an
+  // assertion in HardwareKeyboard.
   //
-  // The assertion only fires in debug builds and the app recovers correctly, so
-  // this is purely console noise. Filtering by string is fragile but it's the
-  // only app-level workaround available without using @visibleForTesting APIs.
+  // The assertion only fires in debug builds and the app recovers
+  // correctly, so this is purely console noise. Filtering by string is
+  // fragile but it's the only app-level workaround available without
+  // using @visibleForTesting APIs.
   // Track: https://github.com/flutter/flutter/issues/131674
   final originalOnError = FlutterError.onError;
   FlutterError.onError = (details) {
@@ -27,11 +31,15 @@ void main() async {
 
   WidgetsFlutterBinding.ensureInitialized();
   final db = await AppDatabase.open();
-  final repo = LocalRideRepository(db);
+  final localRepo = LocalRideRepository(db);
+  final athleteRepo = LocalAthleteRepository(db, localRepo);
 
   runApp(
     ProviderScope(
-      overrides: [rideRepositoryProvider.overrideWithValue(repo)],
+      overrides: [
+        localRideRepositoryProvider.overrideWithValue(localRepo),
+        athleteRepositoryProvider.overrideWithValue(athleteRepo),
+      ],
       child: const SprintPowerAnalyzerApp(),
     ),
   );

--- a/lib/presentation/providers/active_athlete_provider.dart
+++ b/lib/presentation/providers/active_athlete_provider.dart
@@ -1,0 +1,31 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _key = 'active_athlete_id';
+const defaultAthleteId = 'me';
+
+final activeAthleteProvider = NotifierProvider<ActiveAthleteNotifier, String>(
+  ActiveAthleteNotifier.new,
+);
+
+class ActiveAthleteNotifier extends Notifier<String> {
+  @override
+  String build() {
+    unawaited(_load());
+    return defaultAthleteId;
+  }
+
+  Future<void> _load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(_key);
+    if (value != null) state = value;
+  }
+
+  Future<void> setAthlete(String id) async {
+    state = id;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, id);
+  }
+}

--- a/lib/presentation/providers/athlete_list_provider.dart
+++ b/lib/presentation/providers/athlete_list_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+import 'package:wattalizer/presentation/providers/athlete_repository_provider.dart';
+
+final FutureProvider<List<AthleteProfile>> athleteListProvider =
+    FutureProvider.autoDispose<List<AthleteProfile>>((ref) async {
+  final repo = ref.watch(athleteRepositoryProvider);
+  return repo.getAthletes();
+});

--- a/lib/presentation/providers/athlete_repository_provider.dart
+++ b/lib/presentation/providers/athlete_repository_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/domain/interfaces/athlete_repository.dart';
+
+final athleteRepositoryProvider = Provider<AthleteRepository>(
+  (ref) => throw UnimplementedError(
+    'athleteRepositoryProvider must be overridden in ProviderScope',
+  ),
+);

--- a/lib/presentation/providers/max_power_override_provider.dart
+++ b/lib/presentation/providers/max_power_override_provider.dart
@@ -2,8 +2,10 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wattalizer/presentation/providers/active_athlete_provider.dart';
 
-const _key = 'max_power_override';
+const _legacyKey = 'max_power_override';
+String _keyFor(String athleteId) => 'max_power_override_$athleteId';
 
 /// Manual max-power override. null = auto mode (derived from data).
 final maxPowerOverrideProvider =
@@ -14,23 +16,35 @@ final maxPowerOverrideProvider =
 class MaxPowerOverrideNotifier extends Notifier<double?> {
   @override
   double? build() {
-    unawaited(_load());
+    final athleteId = ref.watch(activeAthleteProvider);
+    unawaited(_load(athleteId));
     return null;
   }
 
-  Future<void> _load() async {
+  Future<void> _load(String athleteId) async {
     final prefs = await SharedPreferences.getInstance();
-    final value = prefs.getDouble(_key);
+    final key = _keyFor(athleteId);
+    // Migrate legacy keyless value once (only for the default athlete)
+    if (athleteId == defaultAthleteId && !prefs.containsKey(key)) {
+      final legacy = prefs.getDouble(_legacyKey);
+      if (legacy != null) {
+        await prefs.setDouble(key, legacy);
+        await prefs.remove(_legacyKey);
+      }
+    }
+    final value = prefs.getDouble(key);
     if (value != null) state = value;
   }
 
   Future<void> set(double? value) async {
     state = value;
+    final athleteId = ref.read(activeAthleteProvider);
     final prefs = await SharedPreferences.getInstance();
+    final key = _keyFor(athleteId);
     if (value == null) {
-      await prefs.remove(_key);
+      await prefs.remove(key);
     } else {
-      await prefs.setDouble(_key, value);
+      await prefs.setDouble(key, value);
     }
   }
 }

--- a/lib/presentation/providers/ride_repository_provider.dart
+++ b/lib/presentation/providers/ride_repository_provider.dart
@@ -1,12 +1,22 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/data/database/local_ride_repository.dart';
+import 'package:wattalizer/data/database/scoped_ride_repository.dart';
 import 'package:wattalizer/domain/interfaces/ride_repository.dart';
+import 'package:wattalizer/presentation/providers/active_athlete_provider.dart';
 
-/// Provides the [RideRepository] singleton.
+/// Internal hook for the raw LocalRideRepository.
 /// **Must be overridden** in [ProviderScope] before use.
-/// The database is opened in [main()] and injected as a provider override,
-/// ensuring async DB setup is complete before any provider reads it.
-final rideRepositoryProvider = Provider<RideRepository>(
+final localRideRepositoryProvider = Provider<LocalRideRepository>(
   (ref) => throw UnimplementedError(
-    'rideRepositoryProvider must be overridden in ProviderScope',
+    'localRideRepositoryProvider must be overridden in ProviderScope',
   ),
 );
+
+/// Public provider — derived, scoped to the active athlete.
+/// Existing tests using [rideRepositoryProvider.overrideWithValue(fakeRepo)]
+/// continue to work: Riverpod overrides take precedence over the derived body.
+final rideRepositoryProvider = Provider<RideRepository>((ref) {
+  final athleteId = ref.watch(activeAthleteProvider);
+  final inner = ref.watch(localRideRepositoryProvider);
+  return ScopedRideRepository(inner, athleteId);
+});

--- a/lib/presentation/screens/athlete_list_screen.dart
+++ b/lib/presentation/screens/athlete_list_screen.dart
@@ -1,0 +1,218 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/core/error_types.dart';
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+import 'package:wattalizer/presentation/providers/active_athlete_provider.dart';
+import 'package:wattalizer/presentation/providers/athlete_list_provider.dart';
+import 'package:wattalizer/presentation/providers/athlete_repository_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_session_provider.dart';
+
+class AthleteListScreen extends ConsumerWidget {
+  const AthleteListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final athletesAsync = ref.watch(athleteListProvider);
+    final activeId = ref.watch(activeAthleteProvider);
+    final rideState = ref.watch(rideSessionProvider);
+    final isRiding = rideState is RideStateActive;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Athletes')),
+      body: athletesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (athletes) => ListView.builder(
+          itemCount: athletes.length,
+          itemBuilder: (context, index) {
+            final athlete = athletes[index];
+            final isActive = athlete.id == activeId;
+            return Dismissible(
+              key: ValueKey(athlete.id),
+              direction: DismissDirection.endToStart,
+              confirmDismiss: (_) async {
+                if (isRiding) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text(
+                        'Cannot delete athlete during a ride',
+                      ),
+                    ),
+                  );
+                  return false;
+                }
+                return _confirmDelete(context, athlete.name);
+              },
+              onDismissed: (_) =>
+                  _deleteAthlete(context, ref, athlete, activeId),
+              background: Container(
+                color: Colors.red,
+                alignment: Alignment.centerRight,
+                padding: const EdgeInsets.only(right: 16),
+                child: const Icon(Icons.delete, color: Colors.white),
+              ),
+              child: ListTile(
+                leading: isActive
+                    ? const Icon(
+                        Icons.check,
+                        color: Colors.green,
+                      )
+                    : const SizedBox(width: 24),
+                title: Text(athlete.name),
+                onTap: isRiding
+                    ? null
+                    : () {
+                        unawaited(
+                          ref
+                              .read(activeAthleteProvider.notifier)
+                              .setAthlete(athlete.id),
+                        );
+                        Navigator.pop(context);
+                      },
+                onLongPress: () => _renameAthlete(context, ref, athlete),
+              ),
+            );
+          },
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _createAthlete(context, ref),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  Future<bool> _confirmDelete(
+    BuildContext context,
+    String name,
+  ) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete Athlete'),
+        content: Text(
+          'Delete "$name"? All their rides will be '
+          'permanently deleted.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    return result ?? false;
+  }
+
+  Future<void> _deleteAthlete(
+    BuildContext context,
+    WidgetRef ref,
+    AthleteProfile athlete,
+    String activeId,
+  ) async {
+    try {
+      await ref.read(athleteRepositoryProvider).deleteAthlete(athlete.id);
+      ref.invalidate(athleteListProvider);
+      // If deleted athlete was active, switch to first remaining
+      if (athlete.id == activeId) {
+        final remaining =
+            await ref.read(athleteRepositoryProvider).getAthletes();
+        if (remaining.isNotEmpty) {
+          await ref
+              .read(activeAthleteProvider.notifier)
+              .setAthlete(remaining.first.id);
+        }
+      }
+    } on AthleteDeleteRefused {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Cannot delete the last athlete'),
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _renameAthlete(
+    BuildContext context,
+    WidgetRef ref,
+    AthleteProfile athlete,
+  ) async {
+    final ctrl = TextEditingController(text: athlete.name);
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Rename Athlete'),
+        content: TextField(
+          controller: ctrl,
+          autofocus: true,
+          decoration: const InputDecoration(labelText: 'Name'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, ctrl.text.trim()),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    ctrl.dispose();
+    if (name != null && name.isNotEmpty) {
+      await ref
+          .read(athleteRepositoryProvider)
+          .updateAthlete(athlete.copyWith(name: name));
+      ref.invalidate(athleteListProvider);
+    }
+  }
+
+  Future<void> _createAthlete(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final ctrl = TextEditingController();
+    final name = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('New Athlete'),
+        content: TextField(
+          controller: ctrl,
+          autofocus: true,
+          decoration: const InputDecoration(labelText: 'Name'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, ctrl.text.trim()),
+            child: const Text('Create'),
+          ),
+        ],
+      ),
+    );
+    ctrl.dispose();
+    if (name != null && name.isNotEmpty) {
+      final id = 'athlete_${DateTime.now().millisecondsSinceEpoch}';
+      final athlete = AthleteProfile(
+        id: id,
+        name: name,
+        createdAt: DateTime.now(),
+      );
+      await ref.read(athleteRepositoryProvider).saveAthlete(athlete);
+      ref.invalidate(athleteListProvider);
+    }
+  }
+}

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -3,10 +3,13 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:wattalizer/core/constants.dart';
+import 'package:wattalizer/presentation/providers/active_athlete_provider.dart';
+import 'package:wattalizer/presentation/providers/athlete_list_provider.dart';
 import 'package:wattalizer/presentation/providers/autolap_config_provider.dart';
 import 'package:wattalizer/presentation/providers/max_power_override_provider.dart';
 import 'package:wattalizer/presentation/providers/max_power_provider.dart';
 import 'package:wattalizer/presentation/providers/theme_mode_provider.dart';
+import 'package:wattalizer/presentation/screens/athlete_list_screen.dart';
 import 'package:wattalizer/presentation/screens/autolap_config_list_screen.dart';
 import 'package:wattalizer/presentation/widgets/device_sheet.dart';
 
@@ -20,8 +23,13 @@ class SettingsScreen extends ConsumerWidget {
         child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
-            Text('Settings', style: Theme.of(context).textTheme.headlineSmall),
+            Text(
+              'Settings',
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
             const SizedBox(height: 16),
+            const _AthleteSection(),
+            const Divider(),
             const _AutoLapSection(),
             const Divider(),
             const _MaxPowerSection(),
@@ -30,6 +38,42 @@ class SettingsScreen extends ConsumerWidget {
             const Divider(),
             const _AppearanceSection(),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Athlete
+// ---------------------------------------------------------------------------
+
+class _AthleteSection extends ConsumerWidget {
+  const _AthleteSection();
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final athletesAsync = ref.watch(athleteListProvider);
+    final activeId = ref.watch(activeAthleteProvider);
+
+    final subtitle = athletesAsync.when(
+      loading: () => 'Loading...',
+      error: (_, __) => 'Error',
+      data: (athletes) {
+        final active = athletes.where((a) => a.id == activeId).firstOrNull;
+        return active?.name ?? activeId;
+      },
+    );
+
+    return ListTile(
+      leading: const Icon(Icons.person),
+      title: const Text('Athlete'),
+      subtitle: Text(subtitle),
+      trailing: const Icon(Icons.chevron_right),
+      onTap: () => Navigator.push(
+        context,
+        MaterialPageRoute<void>(
+          builder: (_) => const AthleteListScreen(),
         ),
       ),
     );

--- a/test/core/error_types_test.dart
+++ b/test/core/error_types_test.dart
@@ -87,6 +87,7 @@ void main() {
         ImportError() => 'import',
         ExportError() => 'export',
         InvalidConfigError() => 'invalid_config',
+        AthleteDeleteRefused() => 'athlete_delete_refused',
       };
       expect(label, 'ble_connection');
     });

--- a/test/data/local_athlete_repository_test.dart
+++ b/test/data/local_athlete_repository_test.dart
@@ -1,0 +1,108 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/core/error_types.dart';
+import 'package:wattalizer/data/database/database.dart';
+import 'package:wattalizer/data/database/local_athlete_repository.dart';
+import 'package:wattalizer/data/database/local_ride_repository.dart';
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+import 'package:wattalizer/domain/models/ride.dart';
+import 'package:wattalizer/domain/models/ride_summary.dart';
+
+AppDatabase _openInMemory() => AppDatabase(NativeDatabase.memory());
+
+AthleteProfile _makeAthlete(String id, {String name = 'Test'}) =>
+    AthleteProfile(
+      id: id,
+      name: name,
+      createdAt: DateTime(2024),
+    );
+
+Ride _makeRide(String id) => Ride(
+      id: id,
+      startTime: DateTime(2024),
+      source: RideSource.recorded,
+      summary: const RideSummary(
+        durationSeconds: 60,
+        activeDurationSeconds: 30,
+        avgPower: 300,
+        maxPower: 800,
+        readingCount: 60,
+        effortCount: 1,
+      ),
+    );
+
+void main() {
+  late AppDatabase db;
+  late LocalRideRepository rides;
+  late LocalAthleteRepository repo;
+
+  setUp(() {
+    db = _openInMemory();
+    rides = LocalRideRepository(db);
+    repo = LocalAthleteRepository(db, rides);
+    // The in-memory DB seeds 'me' in onCreate automatically.
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('getAthletes', () {
+    test('returns seeded athlete', () async {
+      final athletes = await repo.getAthletes();
+      expect(athletes, hasLength(1));
+      expect(athletes.first.id, 'me');
+    });
+
+    test('returns multiple athletes sorted by name', () async {
+      await repo.saveAthlete(_makeAthlete('b', name: 'Bob'));
+      await repo.saveAthlete(_makeAthlete('a', name: 'Alice'));
+      final names = (await repo.getAthletes()).map((a) => a.name).toList();
+      expect(names, ['Alice', 'Bob', 'Me']);
+    });
+  });
+
+  group('saveAthlete / getAthlete', () {
+    test('round-trip', () async {
+      final a = _makeAthlete('alice', name: 'Alice');
+      await repo.saveAthlete(a);
+      final fetched = await repo.getAthlete('alice');
+      expect(fetched?.name, 'Alice');
+    });
+
+    test('getAthlete returns null for unknown id', () async {
+      expect(await repo.getAthlete('nope'), isNull);
+    });
+  });
+
+  group('updateAthlete', () {
+    test('updates name', () async {
+      final a = _makeAthlete('me', name: 'Me');
+      await repo.updateAthlete(a.copyWith(name: 'Updated'));
+      final updated = await repo.getAthlete('me');
+      expect(updated?.name, 'Updated');
+    });
+  });
+
+  group('deleteAthlete', () {
+    test('throws AthleteDeleteRefused when only one athlete', () async {
+      expect(
+        () => repo.deleteAthlete('me'),
+        throwsA(isA<AthleteDeleteRefused>()),
+      );
+    });
+
+    test('deletes athlete when others exist', () async {
+      await repo.saveAthlete(_makeAthlete('alice'));
+      await repo.deleteAthlete('alice');
+      expect(await repo.getAthlete('alice'), isNull);
+    });
+
+    test('cascade deletes rides for deleted athlete', () async {
+      await repo.saveAthlete(_makeAthlete('alice'));
+      await rides.saveRideForAthlete(_makeRide('r1'), 'alice');
+      await repo.deleteAthlete('alice');
+      expect(await rides.getRide('r1'), isNull);
+    });
+  });
+}

--- a/test/data/scoped_ride_repository_test.dart
+++ b/test/data/scoped_ride_repository_test.dart
@@ -1,0 +1,85 @@
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/data/database/database.dart';
+import 'package:wattalizer/data/database/local_ride_repository.dart';
+import 'package:wattalizer/data/database/scoped_ride_repository.dart';
+import 'package:wattalizer/domain/models/ride.dart';
+import 'package:wattalizer/domain/models/ride_summary.dart';
+
+AppDatabase _openInMemory() => AppDatabase(NativeDatabase.memory());
+
+Ride _makeRide(String id, {DateTime? startTime}) => Ride(
+      id: id,
+      startTime: startTime ?? DateTime(2024),
+      source: RideSource.recorded,
+      summary: const RideSummary(
+        durationSeconds: 60,
+        activeDurationSeconds: 30,
+        avgPower: 300,
+        maxPower: 800,
+        readingCount: 60,
+        effortCount: 0,
+      ),
+    );
+
+void main() {
+  late AppDatabase db;
+  late LocalRideRepository inner;
+  late ScopedRideRepository scopedA;
+  late ScopedRideRepository scopedB;
+
+  setUp(() {
+    db = _openInMemory();
+    inner = LocalRideRepository(db);
+    scopedA = ScopedRideRepository(inner, 'athleteA');
+    scopedB = ScopedRideRepository(inner, 'athleteB');
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  group('isolation', () {
+    test('rides from other athlete are invisible', () async {
+      await scopedA.saveRide(_makeRide('r1'));
+      final visible = await scopedB.getRides();
+      expect(visible, isEmpty);
+    });
+
+    test('each athlete sees only their own rides', () async {
+      await scopedA.saveRide(_makeRide('rA'));
+      await scopedB.saveRide(_makeRide('rB'));
+
+      final forA = await scopedA.getRides();
+      final forB = await scopedB.getRides();
+
+      expect(forA.map((r) => r.id), contains('rA'));
+      expect(forA.map((r) => r.id), isNot(contains('rB')));
+      expect(forB.map((r) => r.id), contains('rB'));
+      expect(forB.map((r) => r.id), isNot(contains('rA')));
+    });
+
+    test('getRideCount is scoped', () async {
+      await scopedA.saveRide(_makeRide('r1'));
+      await scopedA.saveRide(_makeRide('r2'));
+      await scopedB.saveRide(_makeRide('r3'));
+
+      expect(await scopedA.getRideCount(), 2);
+      expect(await scopedB.getRideCount(), 1);
+    });
+  });
+
+  group('non-scoped operations', () {
+    test('getRide by id works across scopes', () async {
+      await scopedA.saveRide(_makeRide('rA'));
+      final ride = await scopedB.getRide('rA');
+      expect(ride?.id, 'rA');
+    });
+
+    test('deleteRide works from either scope', () async {
+      await scopedA.saveRide(_makeRide('rA'));
+      await scopedB.deleteRide('rA');
+      expect(await scopedA.getRide('rA'), isNull);
+    });
+  });
+}

--- a/test/domain/models/athlete_profile_test.dart
+++ b/test/domain/models/athlete_profile_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+
+void main() {
+  group('AthleteProfile', () {
+    final profile = AthleteProfile(
+      id: 'me',
+      name: 'Me',
+      createdAt: DateTime(2024),
+    );
+
+    group('copyWith', () {
+      test('updates name', () {
+        final updated = profile.copyWith(name: 'Alice');
+        expect(updated.name, 'Alice');
+        expect(updated.id, profile.id);
+        expect(updated.createdAt, profile.createdAt);
+      });
+
+      test('preserves existing name when null', () {
+        final copy = profile.copyWith();
+        expect(copy.name, profile.name);
+      });
+    });
+
+    group('fields', () {
+      test('coachId defaults to null', () {
+        expect(profile.coachId, isNull);
+      });
+
+      test('coachId can be set', () {
+        final withCoach = AthleteProfile(
+          id: 'me',
+          name: 'Me',
+          createdAt: DateTime(2024),
+          coachId: 'coach1',
+        );
+        expect(withCoach.coachId, 'coach1');
+      });
+    });
+  });
+}

--- a/test/presentation/fixtures/fake_athlete_repository.dart
+++ b/test/presentation/fixtures/fake_athlete_repository.dart
@@ -1,0 +1,33 @@
+import 'package:wattalizer/domain/interfaces/athlete_repository.dart';
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+
+class FakeAthleteRepository implements AthleteRepository {
+  List<AthleteProfile> athletes = [
+    AthleteProfile(
+      id: 'me',
+      name: 'Me',
+      createdAt: DateTime(2024),
+    ),
+  ];
+
+  @override
+  Future<List<AthleteProfile>> getAthletes() async => athletes;
+
+  @override
+  Future<AthleteProfile?> getAthlete(String id) async =>
+      athletes.where((a) => a.id == id).firstOrNull;
+
+  @override
+  Future<void> saveAthlete(AthleteProfile athlete) async =>
+      athletes.add(athlete);
+
+  @override
+  Future<void> updateAthlete(AthleteProfile athlete) async {
+    final idx = athletes.indexWhere((a) => a.id == athlete.id);
+    if (idx >= 0) athletes[idx] = athlete;
+  }
+
+  @override
+  Future<void> deleteAthlete(String id) async =>
+      athletes.removeWhere((a) => a.id == id);
+}

--- a/test/presentation/fixtures/test_container.dart
+++ b/test/presentation/fixtures/test_container.dart
@@ -1,20 +1,28 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:wattalizer/presentation/providers/athlete_repository_provider.dart';
 import 'package:wattalizer/presentation/providers/ble_service_provider.dart';
 import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
 
+import 'fake_athlete_repository.dart';
 import 'fake_ble_service.dart';
 import 'fake_repository.dart';
 
 ProviderContainer createTestContainer({
   FakeRepository? repository,
   FakeBleService? bleService,
+  FakeAthleteRepository? athleteRepository,
 }) {
   return ProviderContainer(
     overrides: [
       rideRepositoryProvider.overrideWithValue(
         repository ?? FakeRepository(),
       ),
-      bleServiceProvider.overrideWithValue(bleService ?? FakeBleService()),
+      bleServiceProvider.overrideWithValue(
+        bleService ?? FakeBleService(),
+      ),
+      athleteRepositoryProvider.overrideWithValue(
+        athleteRepository ?? FakeAthleteRepository(),
+      ),
     ],
   );
 }

--- a/test/presentation/providers/active_athlete_provider_test.dart
+++ b/test/presentation/providers/active_athlete_provider_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wattalizer/presentation/providers/active_athlete_provider.dart';
+
+import '../fixtures/test_container.dart';
+
+Future<void> _pump() => Future<void>.delayed(const Duration(milliseconds: 50));
+
+void main() {
+  group('activeAthleteProvider', () {
+    late ProviderContainer container;
+
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    tearDown(() async {
+      await _pump();
+      container.dispose();
+    });
+
+    test('initial state is defaultAthleteId', () {
+      container = createTestContainer();
+      expect(
+        container.read(activeAthleteProvider),
+        defaultAthleteId,
+      );
+    });
+
+    test('setAthlete persists to SharedPreferences', () async {
+      container = createTestContainer();
+      await container.read(activeAthleteProvider.notifier).setAthlete('alice');
+      expect(container.read(activeAthleteProvider), 'alice');
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString('active_athlete_id'), 'alice');
+    });
+
+    test('loads persisted value on rebuild', () async {
+      container = createTestContainer();
+      await container.read(activeAthleteProvider.notifier).setAthlete('alice');
+
+      container
+        ..invalidate(activeAthleteProvider)
+        ..read(activeAthleteProvider);
+      await _pump();
+
+      expect(container.read(activeAthleteProvider), 'alice');
+    });
+  });
+}

--- a/test/presentation/providers/max_power_override_provider_test.dart
+++ b/test/presentation/providers/max_power_override_provider_test.dart
@@ -54,7 +54,8 @@ void main() {
 
       expect(container.read(maxPowerOverrideProvider), 600);
       final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getDouble('max_power_override'), 600);
+      // Per-athlete key for the default athlete 'me'
+      expect(prefs.getDouble('max_power_override_me'), 600);
     });
 
     test('set(null) clears state and removes from SharedPreferences', () async {
@@ -65,7 +66,7 @@ void main() {
 
       expect(container.read(maxPowerOverrideProvider), isNull);
       final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getDouble('max_power_override'), isNull);
+      expect(prefs.getDouble('max_power_override_me'), isNull);
     });
   });
 }


### PR DESCRIPTION
## Summary

Adds multi-athlete profile support. All rides, devices, and autolap configs are now scoped per athlete via a `ScopedRideRepository` wrapper. Switching athletes auto-invalidates downstream providers through Riverpod's dependency graph.

- Athletes table seeded with default 'Me' (id='me'); schemaVersion 4→5
- `rideRepositoryProvider` is now derived from `activeAthleteProvider`
- Per-athlete max power override using SharedPreferences key `max_power_override_$id`
- AthleteListScreen: create, rename, delete, and switch between athletes
- All 421 tests passing, `dart analyze` clean

## Test Plan

- Run `flutter test` — all 421 tests pass
- Manual: create second athlete, verify data isolation
- Manual: switch athletes, confirm provider graph auto-invalidates
- Manual: max power override persists independently per athlete