### PR TITLE
Add canary release channel

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,0 +1,233 @@
+name: Canary Build
+
+on:
+  workflow_run:
+    workflows: ["Smoke Tests"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: canary-build
+  cancel-in-progress: true
+
+jobs:
+  should-build:
+    runs-on: ubuntu-latest
+    # For workflow_run: only proceed if smoke tests passed.
+    # workflow_dispatch always enters (no smoke-test context to check).
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    outputs:
+      proceed: ${{ steps.debounce.outputs.proceed }}
+    steps:
+      - name: Debounce – skip if last success < 1 h ago
+        id: debounce
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LAST=$(gh api \
+            "repos/${{ github.repository }}/actions/workflows/canary.yml/runs?status=success&per_page=1" \
+            --jq '.workflow_runs[0].updated_at // empty')
+          if [ -z "$LAST" ]; then
+            echo "proceed=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          LAST_S=$(date -u -d "$LAST" +%s)
+          NOW_S=$(date -u +%s)
+          if (( NOW_S - LAST_S >= 3600 )); then
+            echo "proceed=true" >> $GITHUB_OUTPUT
+          else
+            echo "proceed=false" >> $GITHUB_OUTPUT
+            echo "Last build was $(( (NOW_S - LAST_S) / 60 ))m ago — skipping"
+          fi
+
+  build-macos:
+    needs: should-build
+    if: needs.should-build.outputs.proceed == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - uses: actions/cache@v4
+        id: gen-cache
+        with:
+          path: |
+            lib/data/database/database.g.dart
+            .dart_tool/build/
+          key: buildrunner-${{ hashFiles('pubspec.lock', 'lib/data/database/tables.dart', 'lib/data/database/database.dart') }}
+
+      - name: Run code generation
+        if: steps.gen-cache.outputs.cache-hit != 'true'
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build macOS
+        run: flutter build macos --release
+
+      - name: Ad-hoc sign
+        run: |
+          codesign --deep --force --sign - \
+            --entitlements macos/Runner/Release.entitlements \
+            build/macos/Build/Products/Release/Wattalizer.app
+
+      - name: Package DMG
+        run: |
+          hdiutil create -volname Wattalizer \
+            -srcfolder build/macos/Build/Products/Release/Wattalizer.app \
+            -ov -format UDZO Wattalizer-canary-macos.dmg
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Wattalizer-canary-macos
+          path: Wattalizer-canary-macos.dmg
+
+  build-windows:
+    needs: should-build
+    if: needs.should-build.outputs.proceed == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: actions/cache@v4
+        with:
+          path: ${{ env.LOCALAPPDATA }}\Pub\Cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - uses: actions/cache@v4
+        id: gen-cache
+        with:
+          path: |
+            lib/data/database/database.g.dart
+            .dart_tool/build/
+          key: buildrunner-${{ hashFiles('pubspec.lock', 'lib/data/database/tables.dart', 'lib/data/database/database.dart') }}
+
+      - name: Run code generation
+        if: steps.gen-cache.outputs.cache-hit != 'true'
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build Windows
+        run: flutter build windows --release
+
+      - name: Package ZIP
+        run: |
+          Compress-Archive -Path build\windows\x64\runner\Release\* `
+            -DestinationPath Wattalizer-canary-windows.zip
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Wattalizer-canary-windows
+          path: Wattalizer-canary-windows.zip
+
+  build-linux:
+    needs: should-build
+    if: needs.should-build.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.lock') }}
+          restore-keys: pub-${{ runner.os }}-
+
+      - name: Install Linux dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y clang cmake ninja-build libgtk-3-dev
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - uses: actions/cache@v4
+        id: gen-cache
+        with:
+          path: |
+            lib/data/database/database.g.dart
+            .dart_tool/build/
+          key: buildrunner-${{ hashFiles('pubspec.lock', 'lib/data/database/tables.dart', 'lib/data/database/database.dart') }}
+
+      - name: Run code generation
+        if: steps.gen-cache.outputs.cache-hit != 'true'
+        run: dart run build_runner build --delete-conflicting-outputs
+
+      - name: Build Linux
+        run: flutter build linux --release
+
+      - name: Package tarball
+        run: |
+          tar -czf Wattalizer-canary-linux.tar.gz \
+            -C build/linux/x64/release/bundle .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Wattalizer-canary-linux
+          path: Wattalizer-canary-linux.tar.gz
+
+  publish:
+    needs: [build-macos, build-windows, build-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: Wattalizer-canary-macos
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Wattalizer-canary-windows
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: Wattalizer-canary-linux
+
+      - name: Create or update canary release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create canary \
+            --repo ${{ github.repository }} \
+            --prerelease \
+            --title "Canary – ${{ github.sha }}" \
+            --notes "Built from \`${{ github.sha }}\` on $(date -u '+%Y-%m-%d %H:%M UTC')" \
+            2>/dev/null || true
+          gh release edit canary \
+            --repo ${{ github.repository }} \
+            --title "Canary – ${{ github.sha }}" \
+            --notes "Built from \`${{ github.sha }}\` on $(date -u '+%Y-%m-%d %H:%M UTC')"
+          gh release upload canary \
+            --repo ${{ github.repository }} \
+            --clobber \
+            Wattalizer-canary-macos.dmg \
+            Wattalizer-canary-windows.zip \
+            Wattalizer-canary-linux.tar.gz

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ Connects to standard Bluetooth Low Energy sensors using open profiles:
 | Heart Rate (0x180D) | Garmin, Polar, Wahoo Tickr |
 | Cycling Speed & Cadence (0x1816) | Garmin, Wahoo |
 
+## Download
+
+| Channel | When to use | Where |
+|---|---|---|
+| **Stable** (tagged release) | Recommended for most users | GitHub Releases → latest versioned tag |
+| **Canary** (built from `main`) | Testing unreleased changes; may be unstable | GitHub Releases → `canary` pre-release |
+
 ## License
 
 This project is licensed under the terms of the MIT license.


### PR DESCRIPTION
## Summary

Adds continuous canary release pipeline for testing unreleased changes. Workflow triggers automatically after Smoke Tests passes on main, with 1-hour debounce to prevent excessive builds. Parallel builds for macOS/Windows/Linux with full caching (Flutter SDK, pub packages, build_runner codegen). Artifacts upload to persistent `canary` pre-release with auto-updated timestamp via gh CLI. README updated with Download section documenting stable vs canary channels.