### PR TITLE
Import: Add GoldenCheetah JSON support

### DIFF
--- a/lib/data/json/gc_json_parser.dart
+++ b/lib/data/json/gc_json_parser.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+
+import 'package:wattalizer/domain/models/sensor_reading.dart';
+
+class GcJsonParseResult {
+  const GcJsonParseResult({
+    required this.startTime,
+    required this.readings,
+  });
+
+  final DateTime startTime;
+  final List<SensorReading> readings;
+}
+
+/// Parses a GoldenCheetah internal JSON ride file.
+///
+/// Format spec derived from GoldenCheetah's JsonRideFile.l / .y grammar.
+/// Top-level structure:
+///   { "RIDE": { "STARTTIME": "...", "RECINTSECS": 1, "SAMPLES": [...] } }
+///
+/// STARTTIME format: "yyyy/MM/dd hh:mm:ss UTC" (always UTC).
+/// SECS: elapsed seconds from ride start (may be fractional).
+///
+/// Null semantics: absent field = null (dropout). WATTS: 0 = valid
+/// coasting (0.0); absent = null.
+class GcJsonParser {
+  static GcJsonParseResult parse(String jsonContent) {
+    final dynamic decoded;
+    try {
+      decoded = jsonDecode(jsonContent);
+    } on FormatException {
+      rethrow;
+    } on Object catch (e) {
+      throw FormatException('Failed to decode JSON: $e');
+    }
+
+    if (decoded is! Map<String, dynamic>) {
+      throw const FormatException('Expected JSON object at top level');
+    }
+
+    // Navigate to the ride map. GC files look like {"RIDE": {...}} where
+    // the value may also be a list (multiple rides joined — take first).
+    final dynamic rideRaw = decoded['RIDE'];
+    final Map<String, dynamic> ride;
+    if (rideRaw is Map<String, dynamic>) {
+      ride = rideRaw;
+    } else if (rideRaw is List && rideRaw.isNotEmpty) {
+      final first = rideRaw.first;
+      if (first is! Map<String, dynamic>) {
+        throw const FormatException('RIDE list element is not an object');
+      }
+      ride = first;
+    } else {
+      throw const FormatException('Missing or empty "RIDE" key');
+    }
+
+    final dynamic startTimeRaw = ride['STARTTIME'];
+    if (startTimeRaw is! String) {
+      throw const FormatException('Missing or invalid "STARTTIME"');
+    }
+    final startTime = _parseStartTime(startTimeRaw);
+
+    final dynamic samplesRaw = ride['SAMPLES'];
+    if (samplesRaw == null) {
+      // No SAMPLES key at all — return empty readings.
+      return GcJsonParseResult(startTime: startTime, readings: const []);
+    }
+    if (samplesRaw is! List) {
+      throw const FormatException('"SAMPLES" must be a list');
+    }
+
+    final readings = <SensorReading>[];
+    for (final dynamic sampleRaw in samplesRaw) {
+      if (sampleRaw is! Map<String, dynamic>) continue;
+
+      final dynamic secsRaw = sampleRaw['SECS'];
+      if (secsRaw == null) continue; // sample without SECS is unusable
+      final secs = (secsRaw as num).toDouble();
+
+      readings.add(
+        SensorReading(
+          timestamp: Duration(milliseconds: (secs * 1000).round()),
+          power: _optDouble(sampleRaw, 'WATTS'),
+          heartRate: _optInt(sampleRaw, 'HR'),
+          cadence: _optDouble(sampleRaw, 'CAD'),
+          crankTorque: _optDouble(sampleRaw, 'NM'),
+          leftRightBalance: _optDouble(sampleRaw, 'LRBALANCE'),
+        ),
+      );
+    }
+
+    readings.sort((a, b) => a.timestamp.compareTo(b.timestamp));
+
+    return GcJsonParseResult(startTime: startTime, readings: readings);
+  }
+
+  /// Converts "yyyy/MM/dd hh:mm:ss UTC" → DateTime (UTC).
+  static DateTime _parseStartTime(String raw) {
+    // "2012/02/29 10:07:33 UTC" → "2012-02-29T10:07:33Z"
+    final s = raw
+        .trim()
+        .replaceFirst(' UTC', 'Z')
+        .replaceAll('/', '-')
+        .replaceFirst(' ', 'T');
+    try {
+      return DateTime.parse(s);
+    } on FormatException {
+      throw FormatException('Cannot parse STARTTIME: "$raw"');
+    }
+  }
+
+  static double? _optDouble(Map<String, dynamic> map, String key) {
+    final v = map[key];
+    if (v == null) return null;
+    return (v as num).toDouble();
+  }
+
+  static int? _optInt(Map<String, dynamic> map, String key) {
+    final v = map[key];
+    if (v == null) return null;
+    return (v as num).toInt();
+  }
+}

--- a/lib/domain/models/ride.dart
+++ b/lib/domain/models/ride.dart
@@ -3,7 +3,7 @@ import 'package:wattalizer/data/database/database.dart';
 import 'package:wattalizer/domain/models/effort.dart';
 import 'package:wattalizer/domain/models/ride_summary.dart';
 
-enum RideSource { recorded, importedTcx, importedFit }
+enum RideSource { recorded, importedTcx, importedFit, importedGcJson }
 
 class Ride {
   const Ride({
@@ -27,6 +27,7 @@ class Ride {
       source: switch (row.source) {
         'recorded' => RideSource.recorded,
         'imported_fit' => RideSource.importedFit,
+        'imported_gc_json' => RideSource.importedGcJson,
         _ => RideSource.importedTcx,
       },
       efforts: efforts,
@@ -55,6 +56,7 @@ class Ride {
         RideSource.recorded => 'recorded',
         RideSource.importedTcx => 'imported_tcx',
         RideSource.importedFit => 'imported_fit',
+        RideSource.importedGcJson => 'imported_gc_json',
       },
       durationSeconds: summary.durationSeconds,
       activeDurationSeconds: summary.activeDurationSeconds,

--- a/lib/domain/services/export_service.dart
+++ b/lib/domain/services/export_service.dart
@@ -6,6 +6,7 @@ import 'package:path_provider/path_provider.dart';
 import 'package:uuid/uuid.dart';
 import 'package:wattalizer/core/error_types.dart';
 import 'package:wattalizer/data/fit/fit_parser.dart';
+import 'package:wattalizer/data/json/gc_json_parser.dart';
 import 'package:wattalizer/data/tcx/tcx_parser.dart';
 import 'package:wattalizer/data/tcx/tcx_serializer.dart';
 import 'package:wattalizer/domain/interfaces/ride_repository.dart';
@@ -166,6 +167,57 @@ class ExportService {
     );
   }
 
+  /// Import a single GoldenCheetah JSON file. Returns a fully populated
+  /// Ride with re-detected efforts.
+  /// Throws [ImportError] on validation failure.
+  Future<Ride> importGcJson(File file, AutoLapConfig config) async {
+    final fileName = file.path.split(Platform.pathSeparator).last;
+
+    if (file.lengthSync() > _maxFileSizeBytes) {
+      throw ImportError(
+        fileName: fileName,
+        type: ImportErrorType.fileTooLarge,
+        detail: 'File exceeds 50 MB limit',
+      );
+    }
+
+    final String content;
+    try {
+      content = file.readAsStringSync();
+    } catch (e) {
+      throw ImportError(
+        fileName: fileName,
+        type: ImportErrorType.malformedFile,
+        detail: 'Read error: $e',
+      );
+    }
+
+    GcJsonParseResult result;
+    try {
+      result = GcJsonParser.parse(content);
+    } on FormatException catch (e) {
+      throw ImportError(
+        fileName: fileName,
+        type: ImportErrorType.malformedFile,
+        detail: e.message,
+      );
+    } catch (e) {
+      throw ImportError(
+        fileName: fileName,
+        type: ImportErrorType.malformedFile,
+        detail: '${e.runtimeType}: $e',
+      );
+    }
+
+    return _importParsedReadings(
+      fileName: fileName,
+      startTime: result.startTime,
+      readings: result.readings,
+      source: RideSource.importedGcJson,
+      config: config,
+    );
+  }
+
   /// Import a ZIP archive of TCX and/or FIT files.
   /// Returns results for each importable file (success or failure per file).
   /// Never throws — errors are collected per file.
@@ -201,7 +253,8 @@ class ExportService {
           (n.endsWith('.tcx') ||
               n.endsWith('.tcx.gz') ||
               n.endsWith('.fit') ||
-              n.endsWith('.fit.gz'));
+              n.endsWith('.fit.gz') ||
+              n.endsWith('.json'));
     }).toList();
     final total = importableFiles.length;
 
@@ -231,6 +284,8 @@ class ExportService {
           final Ride ride;
           if (lowerName.endsWith('.fit') || lowerName.endsWith('.fit.gz')) {
             ride = await importFit(tempFile, config);
+          } else if (lowerName.endsWith('.json')) {
+            ride = await importGcJson(tempFile, config);
           } else {
             ride = await importTcx(tempFile, config);
           }

--- a/lib/presentation/utils/import_utils.dart
+++ b/lib/presentation/utils/import_utils.dart
@@ -12,7 +12,8 @@ import 'package:wattalizer/presentation/providers/historical_range_provider.dart
 import 'package:wattalizer/presentation/providers/max_power_provider.dart';
 import 'package:wattalizer/presentation/providers/ride_list_provider.dart';
 
-/// Routes [filePath] to importFit, importTcx, or importZip based on
+/// Routes [filePath] to importFit, importGcJson, importTcx, or importZip based
+/// on
 /// extension. Invalidates list/range/power providers on success.
 /// Never throws — errors are captured as [ImportResult] entries.
 Future<List<ImportResult>> importFileFromPath(
@@ -36,7 +37,9 @@ Future<List<ImportResult>> importFileFromPath(
       try {
         final ride = name.endsWith('.fit') || name.endsWith('.fit.gz')
             ? await export.importFit(file, config)
-            : await export.importTcx(file, config);
+            : name.endsWith('.json')
+                ? await export.importGcJson(file, config)
+                : await export.importTcx(file, config);
         results = [ImportResult(fileName: fileName, ride: ride)];
       } on ImportError catch (e) {
         results = [ImportResult(fileName: fileName, error: e)];

--- a/lib/presentation/widgets/import_fab.dart
+++ b/lib/presentation/widgets/import_fab.dart
@@ -21,7 +21,7 @@ class _ImportFabState extends ConsumerState<ImportFab> {
     try {
       result = await FilePicker.platform.pickFiles(
         type: FileType.custom,
-        allowedExtensions: ['tcx', 'fit', 'zip', 'gz'],
+        allowedExtensions: ['tcx', 'fit', 'zip', 'gz', 'json'],
         withData: true,
       );
     } on Exception catch (e) {

--- a/test/data/gc_json_parser_test.dart
+++ b/test/data/gc_json_parser_test.dart
@@ -1,0 +1,239 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/data/json/gc_json_parser.dart';
+
+// A well-formed GC JSON file with a variety of sample fields.
+const _sampleJson = '''
+{
+  "RIDE": {
+    "STARTTIME": "2012/02/29 10:07:33 UTC",
+    "RECINTSECS": 1,
+    "DEVICETYPE": "Joule GPS",
+    "IDENTIFIER": "abc123",
+    "TAGS": { "Sport": "Cycling" },
+    "INTERVALS": [
+      { "NAME": "Sprint 1", "START": 2.0, "STOP": 5.0 }
+    ],
+    "SAMPLES": [
+      { "SECS": 0, "WATTS": 0, "HR": 150, "CAD": 90 },
+      { "SECS": 1, "WATTS": 350, "HR": 168, "CAD": 115, "NM": 22.5,
+        "LRBALANCE": 51.0 },
+      { "SECS": 2, "WATTS": 1200, "HR": 172, "CAD": 120 },
+      { "SECS": 3, "HR": 175, "CAD": 118 },
+      { "SECS": 4 }
+    ]
+  }
+}
+''';
+
+// Minimal valid file — no optional fields.
+const _minimalJson = '''
+{
+  "RIDE": {
+    "STARTTIME": "2026/03/10 08:00:00 UTC",
+    "SAMPLES": []
+  }
+}
+''';
+
+// Sub-second recording interval (0.25s).
+const _subSecondJson = '''
+{
+  "RIDE": {
+    "STARTTIME": "2026/01/01 00:00:00 UTC",
+    "RECINTSECS": 0.25,
+    "SAMPLES": [
+      { "SECS": 0 },
+      { "SECS": 0.25, "WATTS": 400 },
+      { "SECS": 0.5, "WATTS": 420 }
+    ]
+  }
+}
+''';
+
+void main() {
+  group('GcJsonParser.parse', () {
+    test('parses startTime correctly', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.startTime, DateTime.utc(2012, 2, 29, 10, 7, 33));
+    });
+
+    test('returns correct reading count', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings.length, 5);
+    });
+
+    test('reads power (WATTS=0 → 0.0, not null)', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      // SECS=0 has WATTS: 0 — valid coasting
+      expect(result.readings[0].power, 0.0);
+    });
+
+    test('reads positive WATTS', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings[1].power, 350.0);
+      expect(result.readings[2].power, 1200.0);
+    });
+
+    test('absent WATTS → null (dropout)', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      // SECS=3 has no WATTS key
+      expect(result.readings[3].power, isNull);
+      // SECS=4 has no WATTS key
+      expect(result.readings[4].power, isNull);
+    });
+
+    test('reads HR correctly', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings[0].heartRate, 150);
+      expect(result.readings[1].heartRate, 168);
+    });
+
+    test('absent HR → null', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings[4].heartRate, isNull);
+    });
+
+    test('reads CAD correctly', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings[0].cadence, 90.0);
+      expect(result.readings[1].cadence, 115.0);
+    });
+
+    test('reads NM as crankTorque', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings[1].crankTorque, 22.5);
+      expect(result.readings[0].crankTorque, isNull);
+    });
+
+    test('reads LRBALANCE as leftRightBalance', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings[1].leftRightBalance, 51.0);
+      expect(result.readings[0].leftRightBalance, isNull);
+    });
+
+    test('timestamps are correct Durations', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.readings[0].timestamp, Duration.zero);
+      expect(result.readings[1].timestamp, const Duration(seconds: 1));
+      expect(result.readings[2].timestamp, const Duration(seconds: 2));
+    });
+
+    test('readings are sorted by timestamp', () {
+      // Shuffle the samples in source JSON to verify sort
+      const unsorted = '''
+{
+  "RIDE": {
+    "STARTTIME": "2026/01/01 00:00:00 UTC",
+    "SAMPLES": [
+      { "SECS": 3, "WATTS": 300 },
+      { "SECS": 1, "WATTS": 100 },
+      { "SECS": 2, "WATTS": 200 }
+    ]
+  }
+}
+''';
+      final result = GcJsonParser.parse(unsorted);
+      expect(result.readings.map((r) => r.power), [100.0, 200.0, 300.0]);
+    });
+
+    test('empty SAMPLES → empty readings list', () {
+      final result = GcJsonParser.parse(_minimalJson);
+      expect(result.readings, isEmpty);
+    });
+
+    test('INTERVALS section is ignored (no error)', () {
+      // _sampleJson has INTERVALS — should parse fine
+      expect(() => GcJsonParser.parse(_sampleJson), returnsNormally);
+    });
+
+    test('TAGS and DEVICETYPE are ignored (no error)', () {
+      expect(() => GcJsonParser.parse(_sampleJson), returnsNormally);
+    });
+
+    test('sub-second SECS → Duration in milliseconds', () {
+      final result = GcJsonParser.parse(_subSecondJson);
+      expect(result.readings.length, 3);
+      expect(result.readings[0].timestamp, Duration.zero);
+      expect(result.readings[1].timestamp, const Duration(milliseconds: 250));
+      expect(result.readings[2].timestamp, const Duration(milliseconds: 500));
+    });
+
+    test('WATTS=400 parsed for sub-second sample', () {
+      final result = GcJsonParser.parse(_subSecondJson);
+      expect(result.readings[1].power, 400.0);
+    });
+
+    test('missing STARTTIME throws FormatException', () {
+      const json = '{"RIDE": {"SAMPLES": []}}';
+      expect(
+        () => GcJsonParser.parse(json),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('missing RIDE key throws FormatException', () {
+      const json = '{"STARTTIME": "2026/01/01 00:00:00 UTC"}';
+      expect(
+        () => GcJsonParser.parse(json),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('malformed JSON throws FormatException', () {
+      expect(
+        () => GcJsonParser.parse('{bad json'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('top-level array (non-object) throws FormatException', () {
+      expect(
+        () => GcJsonParser.parse('[1, 2, 3]'),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('RIDE as list — takes first element', () {
+      const json = '''
+{
+  "RIDE": [
+    {
+      "STARTTIME": "2026/03/10 12:00:00 UTC",
+      "SAMPLES": [{ "SECS": 0, "WATTS": 500 }]
+    }
+  ]
+}
+''';
+      final result = GcJsonParser.parse(json);
+      expect(result.startTime, DateTime.utc(2026, 3, 10, 12));
+      expect(result.readings.length, 1);
+      expect(result.readings.first.power, 500.0);
+    });
+  });
+
+  group('GcJsonParser._parseStartTime (via parse)', () {
+    test('leap day parses correctly', () {
+      final result = GcJsonParser.parse(_sampleJson);
+      expect(result.startTime.isUtc, isTrue);
+      expect(result.startTime.year, 2012);
+      expect(result.startTime.month, 2);
+      expect(result.startTime.day, 29);
+      expect(result.startTime.hour, 10);
+      expect(result.startTime.minute, 7);
+      expect(result.startTime.second, 33);
+    });
+
+    test('result is always UTC', () {
+      final result = GcJsonParser.parse(_minimalJson);
+      expect(result.startTime.isUtc, isTrue);
+    });
+
+    test('invalid STARTTIME string throws FormatException', () {
+      const json = '{"RIDE": {"STARTTIME": "not-a-date", "SAMPLES": []}}';
+      expect(
+        () => GcJsonParser.parse(json),
+        throwsA(isA<FormatException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Parse .json ride files from GoldenCheetah's native format alongside TCX/FIT.

New parser handles STARTTIME ("yyyy/MM/dd hh:mm:ss UTC"), fractional SECS for sub-second intervals, correct null semantics (absent WATTS = dropout, WATTS:0 = coasting). ZIP import and file picker extended to .json. 25 parser tests added.

- lib/data/json/gc_json_parser.dart: new parser
- RideSource enum: added importedGcJson
- ExportService: importGcJson() method, importZip() handles .json
- Import UI: .json in file picker and import router