### PR TITLE
Fix: Skip macOS resource-fork files in ZIP import

### DIFF
--- a/lib/domain/services/export_service.dart
+++ b/lib/domain/services/export_service.dart
@@ -218,6 +218,15 @@ class ExportService {
     );
   }
 
+  /// Returns true for macOS resource-fork and metadata files that ZIP tools
+  /// include automatically. These are binary AppleDouble files, not valid
+  /// activity data, so they must be excluded before import parsing.
+  bool _isMacOsMetadataFile(String archivePath) {
+    final lower = archivePath.toLowerCase();
+    final basename = lower.split('/').last;
+    return basename.startsWith('._') || lower.startsWith('__macosx/');
+  }
+
   /// Import a ZIP archive of TCX and/or FIT files.
   /// Returns results for each importable file (success or failure per file).
   /// Never throws — errors are collected per file.
@@ -250,6 +259,7 @@ class ExportService {
     final importableFiles = archive.files.where((f) {
       final n = f.name.toLowerCase();
       return f.isFile &&
+          !_isMacOsMetadataFile(f.name) &&
           (n.endsWith('.tcx') ||
               n.endsWith('.tcx.gz') ||
               n.endsWith('.fit') ||

--- a/test/domain/export_service_test.dart
+++ b/test/domain/export_service_test.dart
@@ -512,6 +512,24 @@ void main() {
 
       expect(progress, [(0, 2), (1, 2), (2, 2)]);
     });
+
+    test('macOS resource-fork and __MACOSX metadata files are silently ignored',
+        () async {
+      final svc = makeService();
+      // macOS ZIP tools add a binary AppleDouble sidecar for every file and
+      // bundle all sidecars under a __MACOSX/ directory.  Both must be
+      // excluded so they never reach the parsers.
+      final zipFile = _makeZipWithBytes(tempDir, {
+        'ride.tcx': _validTcx().codeUnits,
+        '._ride.tcx': [0x00, 0x05, 0x16, 0x07], // AppleDouble magic bytes
+        '__MACOSX/._ride.tcx': [0x00, 0x05, 0x16, 0x07],
+      });
+
+      final results = await svc.importZip(zipFile, config);
+
+      expect(results, hasLength(1));
+      expect(results.first.ride, isNotNull);
+    });
   });
 }
 


### PR DESCRIPTION
Filter out `._*` resource-fork and `__MACOSX/` metadata entries that macOS ZIP tools automatically include. These are binary AppleDouble files, not valid activity data, and previously passed the .tcx extension check before failing as malformedFile errors during parsing.

Adds helper function `_isMacOsMetadataFile()` to document why this filtering occurs, plus test coverage for mixed valid + metadata ZIP archives.

Fixes #74