### PR TITLE
Restore ZIP import progress indicator

### DIFF
--- a/lib/presentation/utils/import_utils.dart
+++ b/lib/presentation/utils/import_utils.dart
@@ -20,6 +20,7 @@ Future<List<ImportResult>> importFileFromPath(
   WidgetRef ref,
   String filePath, {
   String? displayName,
+  void Function(int done, int total)? onProgress,
 }) async {
   final fileName = displayName ?? filePath.split(Platform.pathSeparator).last;
   final name = fileName.toLowerCase();
@@ -32,7 +33,7 @@ Future<List<ImportResult>> importFileFromPath(
 
     List<ImportResult> results;
     if (name.endsWith('.zip')) {
-      results = await export.importZip(file, config);
+      results = await export.importZip(file, config, onProgress: onProgress);
     } else {
       try {
         final ride = name.endsWith('.fit') || name.endsWith('.fit.gz')

--- a/lib/presentation/widgets/import_fab.dart
+++ b/lib/presentation/widgets/import_fab.dart
@@ -15,6 +15,8 @@ class ImportFab extends ConsumerStatefulWidget {
 
 class _ImportFabState extends ConsumerState<ImportFab> {
   bool _importing = false;
+  int _importDone = 0;
+  int _importTotal = 0;
 
   Future<void> _import() async {
     FilePickerResult? result;
@@ -53,16 +55,41 @@ class _ImportFabState extends ConsumerState<ImportFab> {
         ref,
         importPath,
         displayName: file.name,
+        onProgress: (done, total) {
+          if (mounted) {
+            setState(() {
+              _importDone = done;
+              _importTotal = total;
+            });
+          }
+        },
       );
       if (mounted) showImportResultsDialog(context, results);
     } finally {
-      if (mounted) setState(() => _importing = false);
+      if (mounted) {
+        setState(() {
+          _importing = false;
+          _importDone = 0;
+          _importTotal = 0;
+        });
+      }
       await tempDir?.delete(recursive: true);
     }
   }
 
   @override
   Widget build(BuildContext context) {
+    if (_importing && _importTotal > 1) {
+      return FloatingActionButton.extended(
+        onPressed: null,
+        icon: const SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+        label: Text('$_importDone / $_importTotal'),
+      );
+    }
     return FloatingActionButton(
       tooltip: 'Import rides',
       onPressed: _importing ? null : _import,


### PR DESCRIPTION
## Summary
Restore the per-file progress display ("3 / 12") during bulk ZIP imports. Threads the existing `onProgress` callback from `ExportService.importZip` through `importFileFromPath` up to the FAB layer.

When importing a ZIP with multiple files, the FAB switches to an extended variant showing live progress; single-file imports keep the regular spinning FAB.

## Changes
- `import_utils.dart`: add optional `onProgress` param to `importFileFromPath`, thread to `importZip`
- `import_fab.dart`: track done/total in state, pass progress callback, render extended FAB for multi-file imports
- All 447 tests pass