### PR TITLE
[Build] Fix Flutter Assemble run-every-build warning

### DIFF
--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		};
 		33CC111E2044C6BF0003C045 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);


### PR DESCRIPTION
Add alwaysOutOfDate=1 to the Flutter Assemble ShellScript build phase to prevent Xcode from running it on every build. The tripwire file can't be both input and output, so this flag is the correct approach.