### PR TITLE
Add widget tests for presentation screens

### DIFF
--- a/lib/presentation/screens/athlete_list_screen.dart
+++ b/lib/presentation/screens/athlete_list_screen.dart
@@ -168,7 +168,7 @@ class AthleteListScreen extends ConsumerWidget {
         ],
       ),
     );
-    ctrl.dispose();
+    WidgetsBinding.instance.addPostFrameCallback((_) => ctrl.dispose());
     if (name != null && name.isNotEmpty) {
       await ref
           .read(athleteRepositoryProvider)
@@ -203,7 +203,10 @@ class AthleteListScreen extends ConsumerWidget {
         ],
       ),
     );
-    ctrl.dispose();
+    // Defer disposal: the dialog dismiss animation still renders the
+    // TextField after showDialog returns, so disposing ctrl immediately
+    // causes a "used after dispose" error.
+    WidgetsBinding.instance.addPostFrameCallback((_) => ctrl.dispose());
     if (name != null && name.isNotEmpty) {
       final id = 'athlete_${DateTime.now().millisecondsSinceEpoch}';
       final athlete = AthleteProfile(

--- a/test/presentation/fixtures/fake_repository.dart
+++ b/test/presentation/fixtures/fake_repository.dart
@@ -40,6 +40,7 @@ class FakeRepository implements RideRepository {
   List<GetRidesCall> getRidesCalls = [];
   List<GetAllEffortCurvesCall> getAllEffortCurvesCalls = [];
   List<Ride> savedRides = [];
+  List<String> deleteRideCalls = [];
   Map<String, List<SensorReading>> insertedReadingsByRide = {};
   Map<String, List<Effort>> savedEffortsByRide = {};
   Map<String, MapCurve> savedCurves = {};
@@ -76,7 +77,7 @@ class FakeRepository implements RideRepository {
   }
 
   @override
-  Future<void> deleteRide(String id) async {}
+  Future<void> deleteRide(String id) async => deleteRideCalls.add(id);
 
   @override
   Future<List<SensorReading>> getReadings(

--- a/test/presentation/fixtures/pump_app.dart
+++ b/test/presentation/fixtures/pump_app.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:wattalizer/presentation/providers/athlete_repository_provider.dart';
+import 'package:wattalizer/presentation/providers/ble_service_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
+
+import 'fake_athlete_repository.dart';
+import 'fake_ble_service.dart';
+import 'fake_repository.dart';
+
+// wakelock_plus v1.x uses a Pigeon-generated BasicMessageChannel.
+// Returning encoded [null] (StandardMessageCodec success envelope) silences it.
+const _wakelockChannel = 'dev.flutter.pigeon'
+    '.wakelock_plus_platform_interface.WakelockPlusApi.toggle';
+
+/// Call once per widget test file in [setUpAll].
+void setUpWidgetTestMocks() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMessageHandler(_wakelockChannel, (_) async {
+    const codec = StandardMessageCodec();
+    return codec.encodeMessage(<Object?>[null]);
+  });
+  SharedPreferences.setMockInitialValues({});
+}
+
+/// Builds a [ProviderContainer] with the three standard test overrides.
+///
+/// Tests that need additional provider overrides should build a
+/// [ProviderContainer] directly — Dart infers the element type from the
+/// override objects so the unexported `Override` type never needs to be named.
+///
+/// Example:
+/// ```dart
+/// final container = ProviderContainer(
+///   overrides: [
+///     rideRepositoryProvider.overrideWithValue(FakeRepository()),
+///     bleServiceProvider.overrideWithValue(FakeBleService()),
+///     athleteRepositoryProvider.overrideWithValue(FakeAthleteRepository()),
+///     bleConnectionProvider.overrideWith(
+///       (ref) => Stream.value(BleConnectionState.connected),
+///     ),
+///   ],
+/// );
+/// await pumpApp(tester, const MyScreen(), container: container);
+/// ```
+ProviderContainer buildTestContainer({
+  FakeRepository? repository,
+  FakeBleService? bleService,
+  FakeAthleteRepository? athleteRepository,
+}) {
+  return ProviderContainer(
+    overrides: [
+      rideRepositoryProvider.overrideWithValue(
+        repository ?? FakeRepository(),
+      ),
+      bleServiceProvider.overrideWithValue(bleService ?? FakeBleService()),
+      athleteRepositoryProvider.overrideWithValue(
+        athleteRepository ?? FakeAthleteRepository(),
+      ),
+    ],
+  );
+}
+
+/// Pumps [widget] inside a [MaterialApp] wrapped in an
+/// [UncontrolledProviderScope]. Returns the [ProviderContainer] so tests can
+/// inspect provider state after interactions.
+///
+/// Pass [container] to supply a pre-configured container (e.g. with extra
+/// provider overrides). When omitted, [buildTestContainer] is called with the
+/// optional [repository], [bleService], and [athleteRepository] fakes.
+Future<ProviderContainer> pumpApp(
+  WidgetTester tester,
+  Widget widget, {
+  FakeRepository? repository,
+  FakeBleService? bleService,
+  FakeAthleteRepository? athleteRepository,
+  ProviderContainer? container,
+  Size surfaceSize = const Size(390, 844),
+}) async {
+  final c = container ??
+      buildTestContainer(
+        repository: repository,
+        bleService: bleService,
+        athleteRepository: athleteRepository,
+      );
+
+  await tester.binding.setSurfaceSize(surfaceSize);
+  // Pump pending frames before disposing to avoid "dirty widget in wrong
+  // build scope" errors from async providers that complete after the test.
+  addTearDown(() async {
+    await tester.pumpAndSettle();
+    c.dispose();
+    await tester.binding.setSurfaceSize(null);
+  });
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: c,
+      child: MaterialApp(
+        debugShowCheckedModeBanner: false,
+        theme: ThemeData.dark(useMaterial3: true),
+        home: widget,
+      ),
+    ),
+  );
+
+  return c;
+}

--- a/test/presentation/screens/athlete_list_screen_test.dart
+++ b/test/presentation/screens/athlete_list_screen_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/events/autolap_events.dart';
+import 'package:wattalizer/domain/models/athlete_profile.dart';
+import 'package:wattalizer/presentation/providers/athlete_repository_provider.dart';
+import 'package:wattalizer/presentation/providers/ble_service_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_session_provider.dart';
+import 'package:wattalizer/presentation/screens/athlete_list_screen.dart';
+
+import '../fixtures/fake_athlete_repository.dart';
+import '../fixtures/fake_ble_service.dart';
+import '../fixtures/fake_repository.dart';
+import '../fixtures/pump_app.dart';
+
+class _ActiveNotifier extends RideSessionNotifier {
+  @override
+  RideState build() => RideStateActive(
+        rideId: 'r1',
+        startTime: DateTime(2025, 3, 10),
+        readings: const [],
+        completedEfforts: const [],
+        autoLapState: AutoLapState.idle,
+        currentBaseline: 0,
+      );
+}
+
+void main() {
+  setUpAll(setUpWidgetTestMocks);
+
+  group('AthleteListScreen', () {
+    testWidgets('lists athletes with active marker', (tester) async {
+      final athleteRepo = FakeAthleteRepository()
+        ..athletes = [
+          AthleteProfile(id: 'me', name: 'Me', createdAt: DateTime(2024)),
+          AthleteProfile(id: 'a2', name: 'Alice', createdAt: DateTime(2024)),
+        ];
+      await pumpApp(
+        tester,
+        const AthleteListScreen(),
+        athleteRepository: athleteRepo,
+      );
+      await tester.pump();
+
+      expect(find.text('Me'), findsOneWidget);
+      expect(find.text('Alice'), findsOneWidget);
+      // Exactly one active-marker check icon (for 'me').
+      expect(find.byIcon(Icons.check), findsOneWidget);
+    });
+
+    testWidgets('create athlete dialog saves new athlete', (tester) async {
+      final athleteRepo = FakeAthleteRepository();
+      await pumpApp(
+        tester,
+        const AthleteListScreen(),
+        athleteRepository: athleteRepo,
+      );
+      await tester.pump();
+
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('New Athlete'), findsOneWidget);
+      await tester.enterText(find.byType(TextField), 'Bob');
+      await tester.tap(find.text('Create'));
+      await tester.pumpAndSettle();
+
+      expect(athleteRepo.athletes.any((a) => a.name == 'Bob'), isTrue);
+    });
+
+    testWidgets('delete blocked during active ride shows SnackBar',
+        (tester) async {
+      final athleteRepo = FakeAthleteRepository()
+        ..athletes = [
+          AthleteProfile(id: 'me', name: 'Me', createdAt: DateTime(2024)),
+        ];
+      final container = ProviderContainer(
+        overrides: [
+          rideRepositoryProvider.overrideWithValue(FakeRepository()),
+          bleServiceProvider.overrideWithValue(FakeBleService()),
+          athleteRepositoryProvider.overrideWithValue(athleteRepo),
+          rideSessionProvider.overrideWith(_ActiveNotifier.new),
+        ],
+      );
+      await pumpApp(
+        tester,
+        const AthleteListScreen(),
+        container: container,
+      );
+      await tester.pump();
+
+      await tester.fling(
+        find.byKey(const ValueKey('me')),
+        const Offset(-500, 0),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Cannot delete athlete during a ride'),
+        findsOneWidget,
+      );
+      expect(athleteRepo.athletes.length, 1);
+    });
+  });
+}

--- a/test/presentation/screens/history_screen_test.dart
+++ b/test/presentation/screens/history_screen_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/interfaces/ride_repository.dart';
+import 'package:wattalizer/domain/models/ride_summary.dart';
+import 'package:wattalizer/presentation/screens/history_screen.dart';
+
+import '../fixtures/fake_repository.dart';
+import '../fixtures/pump_app.dart';
+
+void main() {
+  setUpAll(setUpWidgetTestMocks);
+
+  group('HistoryScreen', () {
+    testWidgets('empty list shows No rides found', (tester) async {
+      final repo = FakeRepository()..ridesToReturn = [];
+      await pumpApp(tester, const HistoryScreen(), repository: repo);
+      await tester.pump();
+
+      expect(find.text('No rides found'), findsOneWidget);
+    });
+
+    testWidgets('non-empty list renders ride card with date', (tester) async {
+      final repo = FakeRepository()
+        ..ridesToReturn = [
+          RideSummaryRow(
+            id: 'r1',
+            startTime: DateTime(2025, 3, 10, 14),
+            tags: const [],
+            summary: const RideSummary(
+              durationSeconds: 3600,
+              activeDurationSeconds: 1800,
+              avgPower: 250,
+              maxPower: 500,
+              readingCount: 3600,
+              effortCount: 3,
+            ),
+          ),
+        ];
+      await pumpApp(tester, const HistoryScreen(), repository: repo);
+      await tester.pump();
+
+      expect(find.text('10/3/2025 14:00'), findsOneWidget);
+      expect(find.byType(Card), findsWidgets);
+    });
+
+    testWidgets('swipe to delete shows dialog then removes card',
+        (tester) async {
+      const rideId = 'r1';
+      final repo = FakeRepository()
+        ..ridesToReturn = [
+          RideSummaryRow(
+            id: rideId,
+            startTime: DateTime(2025, 3, 10, 14),
+            tags: const [],
+            summary: const RideSummary(
+              durationSeconds: 3600,
+              activeDurationSeconds: 1800,
+              avgPower: 250,
+              maxPower: 500,
+              readingCount: 3600,
+              effortCount: 3,
+            ),
+          ),
+        ];
+      await pumpApp(tester, const HistoryScreen(), repository: repo);
+      await tester.pump();
+
+      await tester.fling(
+        find.byKey(const ValueKey(rideId)),
+        const Offset(-500, 0),
+        1000,
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete ride?'), findsOneWidget);
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(repo.deleteRideCalls, contains(rideId));
+      expect(find.byKey(const ValueKey(rideId)), findsNothing);
+    });
+  });
+}

--- a/test/presentation/screens/ride_detail_screen_test.dart
+++ b/test/presentation/screens/ride_detail_screen_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/models/effort.dart';
+import 'package:wattalizer/domain/models/effort_summary.dart';
+import 'package:wattalizer/domain/models/map_curve.dart';
+import 'package:wattalizer/domain/models/ride.dart';
+import 'package:wattalizer/domain/models/ride_summary.dart';
+import 'package:wattalizer/presentation/screens/ride_detail_screen.dart';
+import 'package:wattalizer/presentation/widgets/effort_card.dart';
+
+import '../fixtures/fake_repository.dart';
+import '../fixtures/pump_app.dart';
+
+Ride _makeRide({List<Effort> efforts = const []}) => Ride(
+      id: 'r1',
+      startTime: DateTime(2025, 3, 10, 14),
+      source: RideSource.recorded,
+      efforts: efforts,
+      summary: RideSummary(
+        durationSeconds: 600,
+        activeDurationSeconds: 300,
+        avgPower: 300,
+        maxPower: 500,
+        readingCount: 600,
+        effortCount: efforts.length,
+      ),
+    );
+
+Effort _makeEffort(int number) => Effort(
+      id: 'e$number',
+      rideId: 'r1',
+      effortNumber: number,
+      startOffset: (number - 1) * 60,
+      endOffset: number * 60,
+      type: EffortType.auto,
+      summary: const EffortSummary(
+        durationSeconds: 60,
+        avgPower: 350,
+        peakPower: 450,
+      ),
+      mapCurve: MapCurve(
+        entityId: 'e$number',
+        values: List.filled(90, 350),
+        flags: List.generate(90, (_) => const MapCurveFlags()),
+        computedAt: DateTime(2025),
+      ),
+    );
+
+void main() {
+  setUpAll(setUpWidgetTestMocks);
+
+  group('RideDetailScreen', () {
+    testWidgets('delete ride via popup calls deleteRide', (tester) async {
+      final repo = FakeRepository()..ridesById = {'r1': _makeRide()};
+      await pumpApp(
+        tester,
+        const RideDetailScreen(rideId: 'r1'),
+        repository: repo,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete ride?'), findsOneWidget);
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(repo.deleteRideCalls, contains('r1'));
+    });
+
+    testWidgets('delete effort shows SnackBar and updates repository',
+        (tester) async {
+      final effort1 = _makeEffort(1);
+      final effort2 = _makeEffort(2);
+      final repo = FakeRepository()
+        ..ridesById = {
+          'r1': _makeRide(efforts: [effort1, effort2]),
+        };
+      await pumpApp(
+        tester,
+        const RideDetailScreen(rideId: 'r1'),
+        repository: repo,
+      );
+      await tester.pumpAndSettle();
+
+      // Expand effort card 1 to reveal the delete button.
+      await tester.tap(find.byType(EffortCard).first);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.delete_outline).first);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Remove Effort 1?'), findsOneWidget);
+      await tester.tap(find.text('Remove'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Effort 1 removed'), findsOneWidget);
+      expect(repo.savedEffortsByRide['r1']?.length, 1);
+    });
+
+    testWidgets('cancel delete ride does not call deleteRide', (tester) async {
+      final repo = FakeRepository()..ridesById = {'r1': _makeRide()};
+      await pumpApp(
+        tester,
+        const RideDetailScreen(rideId: 'r1'),
+        repository: repo,
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byType(PopupMenuButton<String>));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Delete ride?'), findsOneWidget);
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(repo.deleteRideCalls, isEmpty);
+    });
+  });
+}

--- a/test/presentation/screens/ride_screen_test.dart
+++ b/test/presentation/screens/ride_screen_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/interfaces/ble_service.dart';
+import 'package:wattalizer/presentation/providers/athlete_repository_provider.dart';
+import 'package:wattalizer/presentation/providers/ble_connection_provider.dart';
+import 'package:wattalizer/presentation/providers/ble_service_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
+import 'package:wattalizer/presentation/providers/ride_session_provider.dart';
+import 'package:wattalizer/presentation/screens/ride_screen.dart';
+
+import '../fixtures/fake_athlete_repository.dart';
+import '../fixtures/fake_ble_service.dart';
+import '../fixtures/fake_repository.dart';
+import '../fixtures/pump_app.dart';
+
+class _ErrorNotifier extends RideSessionNotifier {
+  @override
+  RideState build() => RideStateError(message: 'sensor crashed');
+}
+
+void main() {
+  setUpAll(setUpWidgetTestMocks);
+
+  group('RideScreen', () {
+    testWidgets('idle + disconnected shows connect prompt', (tester) async {
+      await pumpApp(tester, const RideScreen());
+      await tester.pump(); // let StreamProvider emit first value
+
+      expect(
+        find.text('Connect a sensor to start'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('idle + connected shows Start Ride button', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          rideRepositoryProvider.overrideWithValue(FakeRepository()),
+          bleServiceProvider.overrideWithValue(FakeBleService()),
+          athleteRepositoryProvider.overrideWithValue(
+            FakeAthleteRepository(),
+          ),
+          bleConnectionProvider.overrideWith(
+            (ref) => Stream.value(BleConnectionState.connected),
+          ),
+        ],
+      );
+      await pumpApp(tester, const RideScreen(), container: container);
+      await tester.pump();
+
+      expect(find.text('Start Ride'), findsOneWidget);
+    });
+
+    testWidgets('error state shows error message', (tester) async {
+      final container = ProviderContainer(
+        overrides: [
+          rideRepositoryProvider.overrideWithValue(FakeRepository()),
+          bleServiceProvider.overrideWithValue(FakeBleService()),
+          athleteRepositoryProvider.overrideWithValue(
+            FakeAthleteRepository(),
+          ),
+          rideSessionProvider.overrideWith(_ErrorNotifier.new),
+        ],
+      );
+      await pumpApp(tester, const RideScreen(), container: container);
+      await tester.pump();
+
+      expect(find.text('sensor crashed'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Adds comprehensive widget test coverage for presentation screens with a shared test helper.

- New `pumpApp()` test helper handles wakelock/SharedPrefs mocks and provider overrides
- Tests for athlete list, history, ride detail, and ride screens
- Fix: defer TextEditingController.dispose() in athlete_list_screen dialogs to avoid crash during dismiss animation
- Enhanced FakeRepository to track deleteRide calls for verification