### PR TITLE
[GUI] Make autolap presets directly editable

### DIFF
--- a/lib/presentation/screens/autolap_config_list_screen.dart
+++ b/lib/presentation/screens/autolap_config_list_screen.dart
@@ -97,32 +97,31 @@ class AutoLapConfigListScreen extends ConsumerWidget {
               final cfg = configs[i];
               final peak = cfg.minPeakWatts;
               return ListTile(
-                leading: cfg.isDefault
-                    ? const Icon(Icons.check_circle, color: Colors.green)
-                    : const Icon(Icons.radio_button_unchecked),
+                leading: IconButton(
+                  tooltip: cfg.isDefault ? 'Default' : 'Set as default',
+                  icon: cfg.isDefault
+                      ? const Icon(Icons.check_circle, color: Colors.green)
+                      : const Icon(Icons.radio_button_unchecked),
+                  onPressed: cfg.isDefault ? null : () => _setDefault(ref, cfg),
+                ),
                 title: Text(cfg.name),
                 subtitle: Text(
                   '↑${cfg.startDeltaWatts.toStringAsFixed(0)}W '
                   '↓${cfg.endDeltaWatts.toStringAsFixed(0)}W '
                   '${peak != null ? 'peak≥${peak.toStringAsFixed(0)}W' : ''}',
                 ),
-                onTap: cfg.isDefault ? null : () => _setDefault(ref, cfg),
+                onTap: () async {
+                  await Navigator.push(
+                    context,
+                    MaterialPageRoute<void>(
+                      builder: (_) => AutoLapConfigEditScreen(config: cfg),
+                    ),
+                  );
+                  _invalidateBoth(ref);
+                },
                 trailing: Row(
                   mainAxisSize: MainAxisSize.min,
                   children: [
-                    IconButton(
-                      icon: const Icon(Icons.edit),
-                      onPressed: () async {
-                        await Navigator.push(
-                          context,
-                          MaterialPageRoute<void>(
-                            builder: (_) =>
-                                AutoLapConfigEditScreen(config: cfg),
-                          ),
-                        );
-                        _invalidateBoth(ref);
-                      },
-                    ),
                     IconButton(
                       icon: Icon(
                         Icons.delete,

--- a/lib/presentation/screens/redetect_preview_sheet.dart
+++ b/lib/presentation/screens/redetect_preview_sheet.dart
@@ -182,32 +182,6 @@ class _RedetectPreviewSheetState extends ConsumerState<RedetectPreviewSheet> {
     return null;
   }
 
-  Future<void> _makeDefault() async {
-    final repo = ref.read(rideRepositoryProvider);
-    if (_selectedConfig != null) {
-      await repo.saveAutoLapConfig(_selectedConfig!.copyWith(isDefault: true));
-    } else {
-      await repo.saveAutoLapConfig(
-        AutoLapConfig(
-          name: _config.name.isNotEmpty ? _config.name : 'Custom',
-          startDeltaWatts: _config.startDeltaWatts,
-          startConfirmSeconds: _config.startConfirmSeconds,
-          startDropoutTolerance: _config.startDropoutTolerance,
-          endDeltaWatts: _config.endDeltaWatts,
-          endConfirmSeconds: _config.endConfirmSeconds,
-          minEffortSeconds: _config.minEffortSeconds,
-          preEffortBaselineWindow: _config.preEffortBaselineWindow,
-          inEffortTrailingWindow: _config.inEffortTrailingWindow,
-          minPeakWatts: _config.minPeakWatts,
-          isDefault: true,
-        ),
-      );
-    }
-    ref
-      ..invalidate(autoLapConfigProvider)
-      ..invalidate(autoLapConfigListProvider);
-  }
-
   Future<void> _apply() async {
     setState(() => _applying = true);
     final repo = ref.read(rideRepositoryProvider);
@@ -371,16 +345,6 @@ class _RedetectPreviewSheetState extends ConsumerState<RedetectPreviewSheet> {
               TextButton(
                 onPressed: _applying ? null : () => Navigator.pop(context),
                 child: const Text('Cancel'),
-              ),
-              const SizedBox(width: 8),
-              OutlinedButton(
-                onPressed: _applying
-                    ? null
-                    : () async {
-                        await _makeDefault();
-                        await _apply();
-                      },
-                child: const Text('Make Default'),
               ),
               const SizedBox(width: 8),
               FilledButton(

--- a/test/presentation/fixtures/fake_repository.dart
+++ b/test/presentation/fixtures/fake_repository.dart
@@ -35,6 +35,7 @@ class FakeRepository implements RideRepository {
     startDeltaWatts: 200,
     endDeltaWatts: 100,
   );
+  List<AutoLapConfig> autoLapConfigsToReturn = [];
 
   // Call tracking
   List<GetRidesCall> getRidesCalls = [];
@@ -43,6 +44,7 @@ class FakeRepository implements RideRepository {
   Map<String, List<SensorReading>> insertedReadingsByRide = {};
   Map<String, List<Effort>> savedEffortsByRide = {};
   Map<String, MapCurve> savedCurves = {};
+  List<AutoLapConfig> savedAutoLapConfigs = [];
   int transactionCount = 0;
 
   @override
@@ -140,7 +142,8 @@ class FakeRepository implements RideRepository {
   Future<MapCurve?> getRidePdc(String rideId) async => ridePdcs[rideId];
 
   @override
-  Future<List<AutoLapConfig>> getAutoLapConfigs() async => [];
+  Future<List<AutoLapConfig>> getAutoLapConfigs() async =>
+      autoLapConfigsToReturn;
 
   @override
   Future<AutoLapConfig> getDefaultConfig() async => defaultConfigToReturn;
@@ -148,7 +151,10 @@ class FakeRepository implements RideRepository {
   int _nextConfigId = 100;
 
   @override
-  Future<int> saveAutoLapConfig(AutoLapConfig config) async => _nextConfigId++;
+  Future<int> saveAutoLapConfig(AutoLapConfig config) async {
+    savedAutoLapConfigs.add(config);
+    return _nextConfigId++;
+  }
 
   @override
   Future<bool> deleteAutoLapConfig(int id) async => true;

--- a/test/presentation/screens/autolap_config_list_screen_test.dart
+++ b/test/presentation/screens/autolap_config_list_screen_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/models/autolap_config.dart';
+import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
+import 'package:wattalizer/presentation/screens/autolap_config_list_screen.dart';
+
+import '../fixtures/fake_repository.dart';
+
+const _standing = AutoLapConfig(
+  id: 1,
+  name: 'Standing Start',
+  startDeltaWatts: 350,
+  endDeltaWatts: 250,
+  isDefault: true,
+);
+const _flying = AutoLapConfig(
+  id: 2,
+  name: 'Flying Start',
+  startDeltaWatts: 150,
+  endDeltaWatts: 150,
+);
+
+void main() {
+  late FakeRepository repo;
+
+  setUp(() {
+    repo = FakeRepository()
+      ..autoLapConfigsToReturn = [_standing, _flying]
+      ..defaultConfigToReturn = _standing;
+  });
+
+  Widget buildScreen() => ProviderScope(
+        overrides: [rideRepositoryProvider.overrideWithValue(repo)],
+        child: const MaterialApp(home: AutoLapConfigListScreen()),
+      );
+
+  group('AutoLapConfigListScreen', () {
+    testWidgets('renders all config names', (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      expect(find.text('Standing Start'), findsOneWidget);
+      expect(find.text('Flying Start'), findsOneWidget);
+    });
+
+    testWidgets('tapping row opens edit screen', (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      await tester.tap(find.text('Standing Start'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Edit Config'), findsOneWidget);
+    });
+
+    testWidgets('default config shows check_circle icon', (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+      expect(find.byIcon(Icons.radio_button_unchecked), findsOneWidget);
+    });
+
+    testWidgets('tapping leading icon on non-default saves it as default',
+        (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.radio_button_unchecked));
+      await tester.pump();
+
+      expect(repo.savedAutoLapConfigs, isNotEmpty);
+      expect(repo.savedAutoLapConfigs.last.name, 'Flying Start');
+      expect(repo.savedAutoLapConfigs.last.isDefault, isTrue);
+    });
+
+    testWidgets('default config leading icon is not tappable', (tester) async {
+      await tester.pumpWidget(buildScreen());
+      await tester.pump();
+
+      await tester.tap(find.byIcon(Icons.check_circle));
+      await tester.pump();
+
+      expect(repo.savedAutoLapConfigs, isEmpty);
+    });
+  });
+}

--- a/test/presentation/screens/redetect_preview_sheet_test.dart
+++ b/test/presentation/screens/redetect_preview_sheet_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wattalizer/domain/models/autolap_config.dart';
+import 'package:wattalizer/domain/models/ride.dart';
+import 'package:wattalizer/domain/models/ride_summary.dart';
+import 'package:wattalizer/presentation/providers/ride_repository_provider.dart';
+import 'package:wattalizer/presentation/screens/redetect_preview_sheet.dart';
+
+import '../fixtures/fake_repository.dart';
+
+Ride _testRide() => Ride(
+      id: 'r1',
+      startTime: DateTime.utc(2024),
+      source: RideSource.recorded,
+      summary: const RideSummary(
+        durationSeconds: 100,
+        activeDurationSeconds: 50,
+        avgPower: 0,
+        maxPower: 0,
+        readingCount: 0,
+        effortCount: 0,
+      ),
+    );
+
+void main() {
+  late FakeRepository repo;
+
+  setUp(() {
+    repo = FakeRepository()
+      ..autoLapConfigsToReturn = [
+        const AutoLapConfig(
+          id: 1,
+          name: 'Standing Start',
+          startDeltaWatts: 350,
+          endDeltaWatts: 250,
+          isDefault: true,
+        ),
+        const AutoLapConfig(
+          id: 2,
+          name: 'Flying Start',
+          startDeltaWatts: 150,
+          endDeltaWatts: 150,
+        ),
+      ];
+  });
+
+  Widget buildSheet() => ProviderScope(
+        overrides: [rideRepositoryProvider.overrideWithValue(repo)],
+        child: MaterialApp(
+          home: Scaffold(
+            body: RedetectPreviewSheet(ride: _testRide(), readings: const []),
+          ),
+        ),
+      );
+
+  group('RedetectPreviewSheet', () {
+    testWidgets('does not show Make Default button', (tester) async {
+      await tester.pumpWidget(buildSheet());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Make Default'), findsNothing);
+    });
+
+    testWidgets('shows Apply and Cancel buttons', (tester) async {
+      await tester.pumpWidget(buildSheet());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Apply'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+    });
+
+    testWidgets('shows a chip for each available config', (tester) async {
+      await tester.pumpWidget(buildSheet());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Standing Start'), findsOneWidget);
+      expect(find.text('Flying Start'), findsOneWidget);
+    });
+
+    testWidgets('selecting a chip populates the parameter fields',
+        (tester) async {
+      await tester.pumpWidget(buildSheet());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Flying Start'));
+      await tester.pump();
+
+      expect(find.widgetWithText(TextField, '150.0'), findsWidgets);
+    });
+  });
+}


### PR DESCRIPTION
Fixes autolap preset editing UX:

- Config list: tap row opens edit screen; move set-as-default to leading icon
- Redetect sheet: remove Make Default (belongs in settings, not transient sheet)

Now presets are clearly editable in both places without confusion.